### PR TITLE
Add open with hex editor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This an extension for Visual Studio Code 1.46+ which utilizes the custom editor 
 
 - Visual Studio Code 1.46+
 
+## How to Use
+There are three ways to open a file as hex
+1. Trigger the command palette (Ctrl / Cmd + Shift + P) -> Reopen With -> Hex Editor
+2. Right click a file -> Open With -> Hex Editor
+3. Trigger the command palette (Ctrl / Cmd + Shift + P) -> Open File using Hex Editor
+
 ## Extension Settings
 
 This extension contributes the following settings:
@@ -30,7 +36,11 @@ This extension contributes the following settings:
 
 ### 1.0.0
 
-Hex Editor initial release
+- Hex Editor initial release
+
+### 1.0.1
+- Add instructions to the README on how to use the extension
+- Add an Open with HexEditor command
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.13.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
-			"integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q==",
+			"version": "13.13.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+			"integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==",
+			"dev": true
+		},
+		"@types/vscode": {
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
+			"integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 	],
 	"icon": "icon.png",
 	"activationEvents": [
-		"onCustomEditor:hexEditor.hexedit"
+		"onCustomEditor:hexEditor.hexedit",
+		"onCommand:hexEditor.openFile"
 	],
 	"main": "./out/src/extension.js",
 	"contributes": {
@@ -47,6 +48,12 @@
 				],
 				"priority": "option"
 			}
+		],
+		"commands": [
+			{
+				"command": "hexEditor.openFile",
+				"title": "Open file using Hex Editor"
+			}
 		]
 	},
 	"scripts": {
@@ -61,7 +68,7 @@
 	"devDependencies": {
 		"@types/glob": "^7.1.2",
 		"@types/mocha": "^7.0.2",
-		"@types/node": "^13.13.10",
+		"@types/node": "^13.13.12",
 		"@types/vscode": "^1.46.0",
 		"@typescript-eslint/eslint-plugin": "^2.34.0",
 		"@typescript-eslint/parser": "^2.34.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "hexeditor",
 	"displayName": "HexEditor",
 	"description": "Allows Hex Editing inside VS Code",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",
 	"repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import TelemetryReporter   from "vscode-extension-telemetry";
+import TelemetryReporter from "vscode-extension-telemetry";
 const { name, version, aiKey } = require("./../../package.json") as {name: string; version: string; aiKey: string};
 import { HexEditorProvider } from "./hexEditorProvider";
 
@@ -14,6 +14,10 @@ let telemetryReporter: TelemetryReporter;
 export function activate(context: vscode.ExtensionContext): void {
 	console.log("Hexeditor is active!");
 	telemetryReporter = new TelemetryReporter(extensionID, version, aiKey);
+	const openWithCommand = vscode.commands.registerTextEditorCommand("hexEditor.openFile", (textEditor: vscode.TextEditor) => {
+		vscode.commands.executeCommand("vscode.openWith", textEditor.document.uri, "hexEditor.hexedit");
+	});
+	context.subscriptions.push(openWithCommand);
 	context.subscriptions.push(telemetryReporter);
 	context.subscriptions.push(HexEditorProvider.register(context, telemetryReporter));
 }


### PR DESCRIPTION
This updates the README and adds an explicit command to the command palette which allows for opening the file in the hex editor. This command also shows up if you type the word hex. 

This is to address the issues regarding discoverability as outlined in
https://github.com/microsoft/vscode-hexeditor/issues/32 and 
https://github.com/microsoft/vscode-hexeditor/issues/34