### PR TITLE
Better focus

### DIFF
--- a/dist/hexEdit.css
+++ b/dist/hexEdit.css
@@ -51,13 +51,13 @@ body {
 
 
 #hexbody > .row > span {
-    padding: 1px 5px 1px 4px;
+    padding: 4px;
     white-space: pre;
 }
 
 
 #ascii > .row > span {
-    padding: 1px 5px 1px 4px;
+    padding: 4px;
     text-align: right;
     white-space: pre;
 }
@@ -73,7 +73,7 @@ body {
 }
 
 .header > span {
-    padding: 1px 5px 1px 4px;
+    padding: 4px;
 }
 
 .right > .header {
@@ -101,7 +101,12 @@ input:focus {
 }
 
 :focus {
-    outline-color: var(--vscode-statusBar-background) !important;
+    outline-color: var(--vscode-focusBorder) !important;
+}
+
+span:focus {
+    outline-offset: 1px;
+    outline: 2px solid;
 }
 
 #endianness {

--- a/dist/hexEdit.css
+++ b/dist/hexEdit.css
@@ -3,6 +3,7 @@ Licensed under the MIT license. */
 
 body {
     min-width: 1224px;
+    color: var(--vscode-editor-foreground);
     overflow-y: hidden;
     overflow-x: scroll;
 }
@@ -100,7 +101,7 @@ input:focus {
 }
 
 :focus {
-    outline-color: var(--vscode-focusBorder) !important;
+    outline-color: var(--vscode-statusBar-background) !important;
 }
 
 #endianness {


### PR DESCRIPTION
Fix #24. This squares off the text in the editor (wasn't able to fully square the decoded text due to spans not being able to be given a width). This also adds an offset to make the focus pop a bit more per @misolori's suggestion. 