### PR TITLE
Adds better contrast to the header

### DIFF
--- a/dist/hexEdit.css
+++ b/dist/hexEdit.css
@@ -65,11 +65,20 @@ body {
 .header {
     position: sticky;
     top: 0px;
-    border: 1px solid;
     font-weight: bold;
-    background-color: var(--vscode-editor-background);
-    color: var(--vscode-editorLineNumber-foreground);
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-editorLineNumber-activeForeground);
     z-index: 10;
+}
+
+.vscode-high-contrast > .column > .header {
+    border: 1px solid;
+    border-color: var(--vsocde-contrastActiveBorder);
+}
+
+.vscode-high-contrast > #editor-container > .column > .header {
+    border: 1px solid;
+    border-color: var(--vsocde-contrastActiveBorder);
 }
 
 .header > span {


### PR DESCRIPTION
Improves upon #23. Brings the contrast ratio up to 6.45 and removes the border unless in high contrast theme. The gutter is a bit more difficult because the colors mimic that of VS Code and any changes I make seem to make it a bit uglier. 