### PR TITLE
Better utf-8 and utf-16 parsing

### DIFF
--- a/media/byteData.ts
+++ b/media/byteData.ts
@@ -47,6 +47,45 @@ export class ByteData {
 	}
 
 	/**
+	 * @description Converts the byte data to a utf-8 character
+	 * @param {boolean} littleEndian Whether or not it's represented in little endian
+	 * @returns {string} The utf-8 character
+	 */
+	toUTF8(littleEndian: boolean): string {
+		let uint8Data = [this.to8bitUInt()];
+		for (let i = 0; i < 3 && i < this.adjacentBytes.length; i++) {
+			uint8Data.push(this.adjacentBytes[i].to8bitUInt());
+		}
+		if (!littleEndian) {
+			uint8Data = uint8Data.reverse();
+		}
+		const utf8 = new TextDecoder("utf-8").decode(new Uint8Array(uint8Data));
+		// We iterate through the string and immediately reutrn the first character
+		for (const char of utf8) return char;
+		return utf8;
+	}
+
+	/**
+	 * @description Converts the byte data to a utf-16 character
+	 * @param {boolean} littleEndian Whether or not it's represented in little endian
+	 * @returns {string} The utf-16 character
+	 */
+	toUTF16(littleEndian: boolean): string {
+		let uint8Data = [this.to8bitUInt()];
+		if (this.adjacentBytes.length === 0) return "End of File";
+		for (let i = 0; i < 3 && i < this.adjacentBytes.length; i++) {
+			uint8Data.push(this.adjacentBytes[i].to8bitUInt());
+		}
+		if (!littleEndian) {
+			uint8Data = uint8Data.reverse();
+		}
+		const utf16 = new TextDecoder("utf-16").decode(new Uint8Array(uint8Data));
+		// We iterate through the string and immediately reutrn the first character
+		for (const char of utf16) return char;
+		return utf16;
+	}
+
+	/**
 	 * @description Handles converting the ByteData object into many of the unsigned and signed integer formats
 	 * @param {number} numBits The numbers of bits you want represented, must be a multiple of 8 and <= 64
 	 * @param {boolean} signed Whether you want the returned representation to be signed or unsigned

--- a/media/dataInspector.ts
+++ b/media/dataInspector.ts
@@ -49,10 +49,7 @@ export function populateDataInspector(byte_obj: ByteData, littleEndian: boolean)
 		(document.getElementById(`int${numBits}`) as HTMLInputElement).disabled = false;
 		(document.getElementById(`uint${numBits}`) as HTMLInputElement).value = isNaN(Number(unsigned)) ? "End of File" : unsigned.toString();
 		(document.getElementById(`uint${numBits}`) as HTMLInputElement).disabled = false;
-		if (numBits === 16) {
-			(document.getElementById("utf16") as HTMLInputElement).value = isNaN(Number(unsigned)) ? "End of File" : String.fromCharCode(Number(unsigned));
-			(document.getElementById("utf16") as HTMLInputElement).disabled = false;
-		} else if (numBits === 32) {
+		if (numBits === 32) {
 			// The boolean for signed doesn't matter for floats so this could also be 32, false, littleEndian, true
 			const float32 = byte_obj.byteConverter(32, true, littleEndian, true);
 			(document.getElementById("float32") as HTMLInputElement).value = isNaN(Number(float32)) ? "End of File" : float32.toString();
@@ -65,8 +62,10 @@ export function populateDataInspector(byte_obj: ByteData, littleEndian: boolean)
 	(document.getElementById("int64") as HTMLInputElement).disabled = false;
 	(document.getElementById("uint64") as HTMLInputElement).value = isNaN(Number(unsigned64)) ? "End of File" : unsigned64.toString();
 	(document.getElementById("uint64") as HTMLInputElement).disabled = false;
-	(document.getElementById("utf8") as HTMLInputElement).value = String.fromCharCode(byte_obj.to8bitUInt());
+	(document.getElementById("utf8") as HTMLInputElement).value = byte_obj.toUTF8(littleEndian);
 	(document.getElementById("utf8") as HTMLInputElement).disabled = false;
+	(document.getElementById("utf16") as HTMLInputElement).value = byte_obj.toUTF16(littleEndian);
+	(document.getElementById("utf16") as HTMLInputElement).disabled = false;
 	const float64 = byte_obj.byteConverter(64, true, littleEndian, true);
 	(document.getElementById("float64") as HTMLInputElement).value = isNaN(Number(float64)) ? "End of File" : float64.toString();
 	(document.getElementById("float64") as HTMLInputElement).disabled = false;

--- a/media/util.ts
+++ b/media/util.ts
@@ -145,7 +145,7 @@ export function retrieveSelectedByteObject(elements: NodeListOf<Element>): ByteD
 			const byte_object = new ByteData(parseInt(element.innerHTML, 16));
 			let current_element = element.nextElementSibling || element.parentElement.nextElementSibling?.children[0];
 			for (let i = 0; i < 7; i++) {
-				if (!current_element) break;
+				if (!current_element || current_element.innerHTML === "+") break;
 				byte_object.addAdjacentByte(new ByteData(parseInt(current_element.innerHTML, 16)));
 				current_element = current_element.nextElementSibling || current_element.parentElement?.nextElementSibling?.children[0];
 			}


### PR DESCRIPTION
Resolves some of the issues outlined in #84. This doesn't handle grapheme clusters and only support single codepoints (So any unicode character that can be represented in 4 bytes). 