### PR TITLE
Switch from attributes to classes

### DIFF
--- a/media/editHandler.ts
+++ b/media/editHandler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getElementsWithGivenOffset, updateAsciiValue } from "./util";
+import { getElementsWithGivenOffset, updateAsciiValue, getElementsOffset } from "./util";
 import { ByteData } from "./byteData";
 import { messageHandler, virtualHexDocument } from "./hexEdit";
 import { SelectHandler } from "./selectHandler";
@@ -49,7 +49,7 @@ export class EditHandler {
             return;
         }
 
-        const offset: number = parseInt(element.getAttribute("data-offset")!);
+        const offset: number = getElementsOffset(element);
         if (!this.pendingEdit || this.pendingEdit.offset != offset) {
             this.pendingEdit = {
                 offset: offset,
@@ -97,7 +97,7 @@ export class EditHandler {
         if (keyPressed.length != 1) return;
         // No need to call it edited if it's the same value
         if (element.innerText === keyPressed) return;
-        const offset: number = parseInt(element.getAttribute("data-offset")!);
+        const offset: number = getElementsOffset(element);
         const hexElement = getElementsWithGivenOffset(offset)[0];
         // We store all pending edits as hex as ascii isn't always representative due to control characters
         this.pendingEdit = {
@@ -294,7 +294,7 @@ export class EditHandler {
         // We apply as much of the hex data as we can based on the selection
         for (let i = 0; i < selected.length && i < hexData.length; i++) {
             const element = selected[i];
-            const offset: number = parseInt(element.getAttribute("data-offset")!);
+            const offset: number = getElementsOffset(element);
             const currentEdit: DocumentEdit = {
                 offset: offset,
                 previousValue: element.innerText === "+" ? undefined : element.innerText,

--- a/media/eventHandlers.ts
+++ b/media/eventHandlers.ts
@@ -1,30 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getElementsGivenMouseEvent, getElementsWithGivenOffset, retrieveSelectedByteObject } from "./util";
-import { WebViewStateManager } from "./webviewStateManager";
+import { getElementsGivenMouseEvent, getElementsWithGivenOffset, retrieveSelectedByteObject, getElementsOffset } from "./util";
 import { populateDataInspector } from "./dataInspector";
 
 /**
- * @description Handles what should be done when an element is hovered over
+ * @description Toggles the hover on a cell
  * @param {MouseEvent} event The event which is handed to a mouse event listener 
  */
-export function hover(event: MouseEvent): void {
+export function toggleHover(event: MouseEvent): void {
     const elements = getElementsGivenMouseEvent(event);
-    if (!elements) return;
-	elements[0].classList.add("hover");
-	elements[1].classList.add("hover");
-}
-
-/**
- * @description Handles what should be done when an element is no longer hovered over
- * @param {MouseEvent} event The event which is handed to a mouse event listener 
- */
-export function removeHover(event: MouseEvent): void {
-    const elements = getElementsGivenMouseEvent(event);
-    if (!elements) return;
-	elements[0].classList.remove("hover");
-	elements[1].classList.remove("hover");
+    if (elements.length === 0) return;
+	elements[0].classList.toggle("hover");
+	elements[1].classList.toggle("hover");
 }
 
 // This is bound to the on change event for the select which decides to render big or little endian
@@ -35,9 +23,7 @@ export function changeEndianness(): void {
 	if (document.activeElement) {
 		// Since the inspector has no sense of state, it doesn't know what byte it is currently rendering
 		// We must retrieve it based on the dom
-		const offset = document.activeElement.getAttribute("data-offset");
-		if (offset === null) return;
-		const elements = getElementsWithGivenOffset(parseInt(offset));
+		const elements = getElementsWithGivenOffset(getElementsOffset(document.activeElement));
 		const byte_obj = retrieveSelectedByteObject(elements);
 		if (!byte_obj) return;
 		const littleEndian = (document.getElementById("endianness") as HTMLInputElement).value === "little";

--- a/media/util.ts
+++ b/media/util.ts
@@ -72,23 +72,36 @@ export function generateCharacterRanges(): Range[] {
 /**
  * @description Given an offset gets all spans with that offset
  * @param {number} offset The offset to find elements of
- * @returns {NodeListOf<HTMLElement>} returns a list of HTMLElements which have the given offset
+ * @returns {HTMLCollectionOf<HTMLElement>} returns a list of HTMLElements which have the given offset
  */
-export function getElementsWithGivenOffset(offset: number): NodeListOf<HTMLElement> {
-    return document.querySelectorAll(`span[data-offset='${offset}'`);
+export function getElementsWithGivenOffset(offset: number): HTMLCollectionOf<HTMLElement> {
+    return document.getElementsByClassName(`cell-offset-${offset}`) as HTMLCollectionOf<HTMLElement>;
+}
+
+/**
+ * @description Given an element returns its offset or NaN if it doesn't have one
+ * @param {HTMLElement} element The element to get the offset of
+ * @returns {number} Returns the offset of the element or NaN
+ */
+export function getElementsOffset(element: Element): number {
+    for (const currentClass of element.classList) {
+        if (currentClass.indexOf("cell-offset") !== -1) {
+            const offset = parseInt(currentClass.replace("cell-offset-", ""));
+            return offset;
+        }
+    }
+    return NaN;
 }
 
 /**
  * @description Returns the elements with the same offset as the one clicked
  * @param {MouseEvent} event The event which is handed to a mouse event listener
- * @returns {NodeListOf<Element> | undefined} The elements with the same offset as the clicked element, or undefined if none could be retrieved
+ * @returns {HTMLCollectionOf<Element> | Array<Element>} The elements with the same offset as the clicked element, or undefined if none could be retrieved
  */
-export function getElementsGivenMouseEvent(event: MouseEvent): NodeListOf<Element> | undefined {
-    if (!event || !event.target) return;
+export function getElementsGivenMouseEvent(event: MouseEvent): HTMLCollectionOf<Element> | Array<Element> {
+    if (!event || !event.target) return [];
     const hovered = event.target as Element;
-    const data_offset = hovered.getAttribute("data-offset");
-    if (!data_offset) return;
-    return getElementsWithGivenOffset(parseInt(data_offset));
+    return getElementsWithGivenOffset(getElementsOffset(hovered));
 }
 
 /**
@@ -123,10 +136,10 @@ export function pad(number: string, width: number): string {
 
 /**
  * @description Given two elements (the hex and ascii elements), returns a ByteData object representing both of them
- * @param {NodeListOf<Element>} elements The elements representing the hex and associated ascii on the DOM
+ * @param {HTMLCollectionOf<Element>} elements The elements representing the hex and associated ascii on the DOM
  * @returns {ByteData | undefined} The ByteData object or undefined if elements was malformed or empty
  */
-export function retrieveSelectedByteObject(elements: NodeListOf<Element>): ByteData | undefined {
+export function retrieveSelectedByteObject(elements: HTMLCollectionOf<Element>): ByteData | undefined {
     for (const element of Array.from(elements)) {
         if (element.parentElement && element.classList.contains("hex")) {
             const byte_object = new ByteData(parseInt(element.innerHTML, 16));


### PR DESCRIPTION
Switch from using attributes to represent the offset of a cell to classes for faster querying of the DOM.