### PR TITLE
Allow a base address to be added to a file via a URI

### DIFF
--- a/media/hexEdit.ts
+++ b/media/hexEdit.ts
@@ -33,7 +33,7 @@ function openAnyway(): void {
 					// Loads the html body sent over
 					if (body.html !== undefined) {
 						document.getElementsByTagName("body")[0].innerHTML = body.html;
-						virtualHexDocument = new VirtualDocument(body.fileSize);
+						virtualHexDocument = new VirtualDocument(body.fileSize, body.baseAddress);
 						// We initially load 4 chunks below the viewport (normally we buffer 2 above as well, but there is no above at the start)
 						chunkHandler.ensureBuffer(virtualHexDocument.topOffset(), {
 							topBufferSize: 0,

--- a/media/virtualDocument.ts
+++ b/media/virtualDocument.ts
@@ -22,6 +22,7 @@ export interface VirtualizedPacket {
  */
 export class VirtualDocument {
     private fileSize: number;
+    private baseAddress: number;
     private rowHeight: number;
     public readonly documentHeight: number;
     private viewPortHeight!: number
@@ -37,8 +38,9 @@ export class VirtualDocument {
      * @description Constructs a VirtualDocument for a file of a given size. Also handles the initial DOM layout
      * @param {number} fileSize The size, in bytes, of the file which is being displayed
      */
-    constructor(fileSize: number) {
+    constructor(fileSize: number, baseAddress = 0) {
         this.fileSize = fileSize;
+        this.baseAddress = baseAddress;
         this.editHandler = new EditHandler();
         this.selectHandler = new SelectHandler();
         this.searchHandler = new SearchHandler();
@@ -266,9 +268,10 @@ export class VirtualDocument {
     private populateHexAdresses(fragment: DocumentFragment, rowData: VirtualizedPacket[]): void {
         const offset = rowData[0].offset;
         const addr = document.createElement("div");
+        const displayOffset = offset + this.baseAddress;
         addr.className = "row";
         addr.setAttribute("data-offset", offset.toString());
-        addr.innerText = pad(offset.toString(16), 8).toUpperCase();
+        addr.innerText = pad(displayOffset.toString(16), 8).toUpperCase();
         fragment.appendChild(addr);
         this.rows[0].set(offset.toString(), addr);
         // We add a left px offset to effectively right align the column

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "hexeditor",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -636,6 +636,16 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -1858,6 +1868,13 @@
 			"requires": {
 				"flat-cache": "^2.0.1"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -3132,6 +3149,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -4921,7 +4945,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "hexeditor",
 	"displayName": "Hex Editor",
 	"description": "Allows Hex Editing inside VS Code",
-	"version": "1.2.2-pre1",
+	"version": "1.2.1",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "hexeditor",
 	"displayName": "Hex Editor",
 	"description": "Allows Hex Editing inside VS Code",
-	"version": "1.2.1",
+	"version": "1.2.2-pre1",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",
 	"repository": {

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -46,9 +46,6 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 		const fileSize = (await vscode.workspace.fs.stat(dataFile)).size;
 		const queries = HexDocument.parseQuery(uri.query);
 		const baseAddress: number = queries["baseAddress"] ? HexDocument.parseHexOrDecInt(queries["baseAddress"]) : 0;
-		fs.writeFileSync("/tmp/haneef.1", "file: " + dataFile + "\n");
-		fs.writeFileSync("/tmp/haneef.1", "query:" + uri.query + "\n", { flag: "a" });
-		fs.writeFileSync("/tmp/haneef.1", "baseAddress:" + baseAddress.toString() + "\n", { flag: "a" });
 		/* __GDPR__
 			"fileOpen" : {
 				"fileSize" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -66,10 +66,8 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 		}));
 
 		const watcher = vscode.workspace.createFileSystemWatcher(uri.fsPath); 
-		fs.writeFileSync("/tmp/haneef.1", "Watcher:" + uri.fsPath + "\n", { flag: "a" });
 		listeners.push(watcher);
 		listeners.push(watcher.onDidChange(e => {
-			fs.writeFileSync("/tmp/haneef.1", "Watcher update:" + uri.fsPath + "\n", { flag: "a" });
 			if (e.toString() === uri.toString()) {
 				if (document.unsavedEdits.length > 0) {
 					const message = "This file has changed on disk, but you have unsaved changes. Saving now will overwrite the file on disk with your changes.";


### PR DESCRIPTION
I apologize if I didn't do things right. Even tabs vs. spaces. I am not a TypeScript expert either. Please review and I will do whatever is needed.

Basically, even if you are reading a file, the base address is not always zero. This is an awesome extension and I want to use it in a debugger. I am trying to address Issue #70 that I filed. It is only one part of the solution.

**Bottom line: adds an offset to the addresses displayed**

Yes, I have some imports for `fs` as I was using them for debugging and logging. As I found out, debugging two extensions at the same time was a bit challenging.

Btw, `npm install` fails for me because I don't have the `nan` package installed globally. I can fix `package.json` if you want.