### PR TITLE
Editor Search Widget

### DIFF
--- a/dist/hexEdit.css
+++ b/dist/hexEdit.css
@@ -156,7 +156,14 @@ select:not(.inline-select) {
 }
 
 #search-container {
-    padding-top: 20px;
+    position: absolute;
+    display: none;
+    height: 100px;
+    width: 300px;
+    top: -85px;
+    padding: 2px 2px 2px 2px;
+    right: 4%;
+    background-color: var(--vscode-editor-background);
 }
 
 .endian-select {
@@ -299,7 +306,8 @@ button:disabled {
     padding-bottom: 10px;
 }
 
-#search-container > .header, #data-inspector > .header {
+#search-container > .header {
+    position: relative;
     font-weight: bold;
     font-family: var(--vscode-font-family);
     

--- a/media/editor/searchHandler.ts
+++ b/media/editor/searchHandler.ts
@@ -158,8 +158,11 @@ export class SearchHandler {
      * @description Sends a search request to the exthost
      */
     private async search(): Promise<void> {
-        // If the box is empty no need to display any warnings
-        if (this.findTextBox.value === "") this.removeInputMessage("find");
+        // If the box is empty no need to display any warnings or execute a search
+        if (this.findTextBox.value === "") {
+            this.removeInputMessage("find");
+            return;
+        }
         // This gets called to cancel any searches that might be going on now
         this.cancelSearch();
         virtualHexDocument.setSelection([]);

--- a/media/editor/searchHandler.ts
+++ b/media/editor/searchHandler.ts
@@ -413,6 +413,7 @@ export class SearchHandler {
         this.searchType = document.activeElement?.classList.contains("ascii") ? "ascii" : "hex";
         const dataTypeSelect = (document.getElementById("data-type") as HTMLSelectElement);
         dataTypeSelect.value = this.searchType;
+        // We have to get and then set the state as this dispatch event appears to clear the webview state
         dataTypeSelect.dispatchEvent(new Event("change"));
         this.findTextBox.focus();
     }
@@ -460,10 +461,12 @@ export class SearchHandler {
      * @description Reveals the find widget, similar to how the default editor does it
      */
     private showWidget(): void {
+        // Don't trigger the show animation again if it's already shown
+        if (this.searchContainer.style.display === "block") return;
         this.searchContainer.style.display = "block";
         let currentTop = -85;
         const frameInterval = setInterval(() => {
-            if (currentTop === 0) {
+            if (currentTop === -4) {
                 clearInterval(frameInterval);
             } else {
                 currentTop++;
@@ -476,7 +479,7 @@ export class SearchHandler {
      * @description Hides the find widget, similar to how the default editor does it
      */
     private hideWidget(): void {
-        let currentTop = 0;
+        let currentTop = -4;
         const frameInterval = setInterval(() => {
             if (currentTop === -85) {
                 this.searchContainer.style.display = "none";

--- a/media/editor/selectHandler.ts
+++ b/media/editor/selectHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { getElementsWithGivenOffset, relativeComplement, binarySearch, disjunction } from "./util";
-import { WebViewStateManager } from "./webviewStateManager";
+import { WebviewStateManager } from "./webviewStateManager";
 
 export class SelectHandler {
     private _focus: number | undefined;
@@ -54,7 +54,7 @@ export class SelectHandler {
      * @returns {number[]} The offsets of the elements currently selected
      */
     public getSelected(): number[] {
-        return WebViewStateManager.getProperty("selected_offsets") ?? [];
+        return WebviewStateManager.getProperty("selected_offsets") ?? [];
     }
 
     /***
@@ -69,7 +69,7 @@ export class SelectHandler {
 
         this._selectionStart = start;
         this._selection = [...offsets].sort((a: number, b: number) => a - b);
-        WebViewStateManager.setProperty("selected_offsets", this._selection);
+        WebviewStateManager.setProperty("selected_offsets", this._selection);
 
         // Need to call renderSelection with the least number of offsets to avoid querying the DOM
         // as much as possible, if not rendering large selections becomes laggy as we dont hold references

--- a/media/editor/srollBarHandler.ts
+++ b/media/editor/srollBarHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license
 
 import { virtualHexDocument } from "./hexEdit";
-import { WebViewStateManager } from "./webviewStateManager";
+import { WebviewStateManager } from "./webviewStateManager";
 
 export class ScrollBarHandler {
     private scrollBar: HTMLDivElement;
@@ -161,7 +161,7 @@ export class ScrollBarHandler {
         this.scrollTop = Math.max(0, newScrollTop);
         newScrollTop = this.scrollTop;
         this.scrollTop = Math.min(newScrollTop, ((this.scrollBarHeight - this.scrollThumbHeight) * this.scrollJump) + this.rowHeight);
-        WebViewStateManager.setProperty("scroll_top", this.scrollTop);
+        WebviewStateManager.setProperty("scroll_top", this.scrollTop);
     }
 
     /**
@@ -177,8 +177,8 @@ export class ScrollBarHandler {
      */
     public resyncScrollPosition(): void {
         // If we had a previously saved state when creating the scrollbar we should restore the scroll position
-        if (WebViewStateManager.getState() && WebViewStateManager.getState().scroll_top) {
-            this.updateVirtualScrollTop(WebViewStateManager.getState().scroll_top);
+        if (WebviewStateManager.getState() && WebviewStateManager.getState().scroll_top) {
+            this.updateVirtualScrollTop(WebviewStateManager.getState().scroll_top);
             this.updateScrolledPosition();
         }
     }

--- a/media/editor/virtualDocument.ts
+++ b/media/editor/virtualDocument.ts
@@ -7,7 +7,7 @@ import { toggleHover } from "./eventHandlers";
 import { chunkHandler, virtualHexDocument } from "./hexEdit";
 import { ScrollBarHandler } from "./srollBarHandler";
 import { EditHandler, EditMessage } from "./editHandler";
-import { WebViewStateManager } from "./webviewStateManager";
+import { WebviewStateManager } from "./webviewStateManager";
 import { SelectHandler } from "./selectHandler";
 import { SearchHandler } from "./searchHandler";
 import { DataInspectorHandler } from "./dataInspectorHandler";
@@ -97,14 +97,14 @@ export class VirtualDocument {
         document.getElementById("hexbody")?.appendChild(hexFragment);
         document.getElementById("ascii")?.appendChild(asciiFragment);
 
-        if (WebViewStateManager.getState()) {
+        if (WebviewStateManager.getState()) {
             const selectedOffsets = this.selectHandler.getSelected();
             if (selectedOffsets.length > 0) {
                 this.selectHandler.setSelected(selectedOffsets, selectedOffsets[0], true);
             }
             // This isn't the best place for this, but it can't go in the constructor due to the document not being instantiated yet
             // This ensures that the srollTop is the same as in the state object, should only be out of sync on initial webview load
-            const savedScrollTop = WebViewStateManager.getState().scroll_top;
+            const savedScrollTop = WebviewStateManager.getState().scroll_top;
             if (savedScrollTop && savedScrollTop !== this.scrollBarHandler.virtualScrollTop) {
                 this.scrollBarHandler.resyncScrollPosition();
             }

--- a/media/editor/webviewStateManager.ts
+++ b/media/editor/webviewStateManager.ts
@@ -7,7 +7,7 @@ import { vscode } from "./hexEdit";
  * Simple static class which handles setting and clearing the webviews state
  * We use this over the default .setState as it implements a setState which doesn't override the entire object just the given property
  */
-export class WebViewStateManager {
+export class WebviewStateManager {
 
     /**
      * @description Given a property and a value either updates or adds it to the state
@@ -15,7 +15,7 @@ export class WebViewStateManager {
      * @param {any} propertyValue The value to store for the property
      */
     static setProperty(propertyName: string, propertyValue: any): void {
-        let currentState = WebViewStateManager.getState();
+        let currentState = WebviewStateManager.getState();
         if (currentState === undefined) {
             currentState = { };
         }
@@ -38,11 +38,19 @@ export class WebViewStateManager {
     }
 
     /**
+     * @description Sets the state of the webview to whatever object is passed in, completely overriding it
+     * @param state The state object
+     */
+    static setState(state: any): void {
+        vscode.setState(state);
+    }
+
+    /**
      * @description Retrieves a property on the state object
      * @param {string} propertyName The name of the property to retrieve the value of
      */
     static getProperty(propertyName: string): any {
-        const state =  WebViewStateManager.getState();
+        const state =  WebviewStateManager.getState();
         return state[propertyName];
     }
 }

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -253,50 +253,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 				</div>
 			</div>
 		</div>
-		<div class="column">
-			<div id="search-container">
-				<div class="header">
-					SEARCH IN
-					<span>
-						<select id="data-type" class="inline-select">
-							<option value="hex">Hex</option>
-							<option value="ascii">Text</option>
-						</select>
-					</span>
-				</div>
-				<div class="search-widget">
-					<div class="bar find-bar">
-						<span class="input-glyph-group">
-							<input type="text" autocomplete="off" spellcheck="off" name="find" id="find" placeholder="Find"/>
-							<span class="bar-glyphs">
-								<span class="codicon codicon-case-sensitive" id="case-sensitive" title="Match Case"></span>
-								<span class="codicon codicon-regex" id="regex-icon" title="Use Regular Expression"></span>
-							</span>
-							<div id="find-message-box">
-							</div>
-						</span>
-						<span class="icon-group">
-							<span class="codicon codicon-search-stop disabled" id="search-stop" title="Cancel Search"></span>
-							<span class="codicon codicon-arrow-up disabled" id="find-previous" title="Previous Match"></span>
-							<span class="codicon codicon-arrow-down disabled" id="find-next" title="Next Match"></span>
-						</span>
-					</div>
-					<div class="bar replace-bar">
-						<span class="input-glyph-group">
-							<input type="text" autocomplete="off" spellcheck="off" name="replace" id="replace" placeholder="Replace"/>
-							<span class="bar-glyphs">
-								<span class="codicon codicon-preserve-case" id="preserve-case" title="Preserve Case"></span>
-							</span>
-							<div id="replace-message-box">
-					  		</div>
-						</span>
-						<span class="icon-group">
-							<span class="codicon codicon-replace disabled" id="replace-btn" title="Replace"></span>
-							<span class="codicon codicon-replace-all disabled" id="replace-all" title="Replace All"></span>
-						</span>
-					</div>
-				</div>
-			</div>
+		<div id="search-container">
 		</div>
 		`;
 	}


### PR DESCRIPTION
Makes the search widget follow similar behavior to the text editor in VS Code. This is a better and more at home solution than #201. @tigerbeard We will need to figure out what to do with your search results page as it won't feel like a native experience in a pull down widget such as the one you see in VS Code's text editor. Maybe following something similar to #199 would be best for that.