### PR TITLE
Add the ability to go to a certain file offset

### DIFF
--- a/media/editor/virtualDocument.ts
+++ b/media/editor/virtualDocument.ts
@@ -508,10 +508,10 @@ export class VirtualDocument {
     }
 
     /***
-     * @description Populates the inspector data with the currently focused element.
+     * @description Populates the inspector data with the currently selected element.
      */
     private updateInspector(): void {
-        const offset = this.selectHandler.getFocused();
+        const offset = this.selectHandler.getSelectionStart();
         if (offset !== undefined) {
             const elements = getElementsWithGivenOffset(offset);
             const byte_obj = retrieveSelectedByteObject(elements)!;
@@ -535,6 +535,7 @@ export class VirtualDocument {
         const elements = getElementsWithGivenOffset(offset);
         if (elements.length != 2) return;
         this.selectHandler.setSelected([offset], offset);
+        this.updateInspector();
         // If an ascii element is currently focused then we focus that, else we focus hex
         if (document.activeElement?.parentElement?.parentElement?.parentElement?.classList.contains("right")) {
             elements[1].focus();

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
 			{
 				"command": "hexEditor.openFile",
 				"title": "Hex Editor: Open file"
+			},
+			{
+				"command": "hexEditor.goToOffset",
+				"title": "Hex Editor: Go To Offset"
 			}
 		],
 		"viewsContainers": {
@@ -74,6 +78,14 @@
 					"type": "webview",
 					"id": "hexEditor.dataInpsectorView",
 					"name": "Data Inspector",
+					"when": "hexEditor:openEditor"
+				}
+			]
+		},
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "hexEditor.goToOffset",
 					"when": "hexEditor:openEditor"
 				}
 			]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import TelemetryReporter from "vscode-extension-telemetry";
 import { DataInspectorView } from "./dataInspectorView";
 const { name, version, aiKey } = require("./../../package.json") as {name: string; version: string; aiKey: string};
 import { HexEditorProvider } from "./hexEditorProvider";
+import { openOffsetInput } from "./util";
 
 // Telemetry information
 const extensionID = `vscode-${name}`;
@@ -20,6 +21,14 @@ export function activate(context: vscode.ExtensionContext): void {
 	const openWithCommand = vscode.commands.registerTextEditorCommand("hexEditor.openFile", (textEditor: vscode.TextEditor) => {
 		vscode.commands.executeCommand("vscode.openWith", textEditor.document.uri, "hexEditor.hexedit");
 	});
+	const goToOffsetCommand = vscode.commands.registerCommand("hexEditor.goToOffset", async () => {
+		const offset = await openOffsetInput();
+		// Notify the current webview that the user wants to go to a specific offset
+		if (offset && HexEditorProvider.currentWebview) {
+			HexEditorProvider.currentWebview.postMessage({ type: "goToOffset", body: { offset } });
+		}
+	});
+	context.subscriptions.push(goToOffsetCommand);
 	context.subscriptions.push(openWithCommand);
 	context.subscriptions.push(telemetryReporter);
 	context.subscriptions.push(HexEditorProvider.register(context, telemetryReporter, dataInspectorProvider));

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -28,6 +28,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
     }
 
     private static readonly viewType = "hexEditor.hexedit";
+		public static currentWebview?: vscode.Webview;
 
     private readonly webviews = new WebviewCollection();
 
@@ -118,6 +119,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 	): Promise<void> {
 		// Add the webview to our internal set of active webviews
 		this.webviews.add(document.uri, webviewPanel);
+		HexEditorProvider.currentWebview = webviewPanel.webview;
 
 		// Setup initial content for the webview
 		webviewPanel.webview.options = {
@@ -128,7 +130,10 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 		webviewPanel.onDidChangeViewState(e => 	{
 			vscode.commands.executeCommand("setContext", "hexEditor:openEditor", e.webviewPanel.visible);
 			if (e.webviewPanel.visible) {
+				HexEditorProvider.currentWebview = e.webviewPanel.webview;
 				this._dataInspectorView.show(true);
+			} else {
+				HexEditorProvider.currentWebview = undefined;
 			}
 		});
 		webviewPanel.webview.onDidReceiveMessage(e => this.onMessage(webviewPanel, document, e));

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { window } from "vscode";
+
 export function getNonce(): string {
 	let text = "";
 	const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -8,4 +10,16 @@ export function getNonce(): string {
 		text += possible.charAt(Math.floor(Math.random() * possible.length));
 	}
 	return text;
+}
+
+/**
+ * @description Opens the input box so the user can input which offset they want to go to
+ */
+export async function openOffsetInput(): Promise<string | undefined> {
+	return window.showInputBox({
+		placeHolder: "Enter offset to go to",
+		validateInput: text => {
+			return text.length > 8 || new RegExp("^[a-fA-F0-9]+$").test(text) ? null : "Invalid offset string";
+		}
+	});
 }


### PR DESCRIPTION
Adds a command accessible from the command palette that allows a user to go to a specific cell / line offset. This addresses common requests such as #191 and #83. Sadly, it doesn't appear that you can override the `CTRL + G` keybinding and therefore it is only accessible from the command palette at this time.

Resolves #191 and #83.