### PR TITLE
Support different scheme file uris

### DIFF
--- a/src/fileSystemAdaptor.ts
+++ b/src/fileSystemAdaptor.ts
@@ -17,10 +17,8 @@ export abstract class FileSystemAdaptor {
     if (uri.scheme === "untitled") {
       const document = FileSystemAdaptor.findMatchingTextDocument(uri);
       return document ? document.getText().length : 0;
-    } else if (uri.scheme === "file") {
-      return (await vscode.workspace.fs.stat(uri)).size;
     } else {
-      throw `Unsupported URI scheme ${uri.scheme}`;
+      return (await vscode.workspace.fs.stat(uri)).size;
     }
   }
 
@@ -29,10 +27,8 @@ export abstract class FileSystemAdaptor {
       const document = FileSystemAdaptor.findMatchingTextDocument(uri);
       // Conver the document text to bytes and return it
       return document ? new TextEncoder().encode(document.getText()) : new Uint8Array();
-    } else if (uri.scheme === "file") {
-      return vscode.workspace.fs.readFile(uri);
     } else {
-      throw `Unsupported URI scheme ${uri.scheme}`;
+      return vscode.workspace.fs.readFile(uri);
     }
   }
 


### PR DESCRIPTION
Now `vscode.workspace.fs` can use interface exposed by other contributed file system providers. After removing scheme check in `fileSystemAdaptor.ts`, Hex Editor extension is able to edit files provided by other extensions' file system provider (related issue: https://github.com/fython/vscode-gwo-android-helper/issues/1).