### PR TITLE
Tidy up readme/ext description

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,42 @@
-# VS Code Hexeditor
-
-This an extension for Visual Studio Code which utilizes the custom editor API to allow viewing files as hex within VS Code.
+A custom editor extension for Visual Studio Code which provides a hex editor for viewing and manipulating files in their raw hexadecimal representation.
 
 ## Features
 
-- Opening files as HEX
-- Navigating and scrolling through them
-- Viewing the hex values in various different formats
-- Simple editing with undo, redo, copy, and paste support
-- Find and Replace support
+- Opening files as hex
+- A data inspector for viewing the hex values as various different data types
+- Editing with undo, redo, copy, and paste support
+- Find and replace
 
 ![Navigating a file](https://raw.githubusercontent.com/microsoft/vscode-hexeditor/main/hex-editor.gif)
 
 ![Editing a file](https://raw.githubusercontent.com/microsoft/vscode-hexeditor/main/hex-editor-editing.gif)
 
 ## How to Use
-There are three ways to open a file as hex
-1. Trigger the command palette (Ctrl / Cmd + Shift + P) -> Reopen With -> Hex Editor
-2. Right click a file -> Open With -> Hex Editor
-3. Trigger the command palette (Ctrl / Cmd + Shift + P) -> Open File using Hex Editor
 
-If you would like to use the hex editor as the default hex editor for certain file types you can add the `workbench.editorAssociations` setting to your `settings.json`.
+There are three ways to open a file in the hex editor:
 
-For example, this would associate all files with .hex or .ini to open by default in the hex editor
+1. Right click a file -> Open With -> Hex Editor
+2. Trigger the command palette (<kbd>F1</kbd>) -> Open File using Hex Editor
+3. Trigger the command palette (<kbd>F1</kbd>) -> Reopen With -> Hex Editor
+
+The hex editor can be set as the default editor for certain file types by using the `workbench.editorAssociations` setting. For example, this would associate all files with extensions `.hex` and `.ini` to use the hex editor by default:
+
 ```json
-    "workbench.editorAssociations": [
-        {
-            "viewType": "hexEditor.hexedit",
-            "filenamePattern": "*.hex"
-        },
-        {
-            "viewType": "hexEditor.hexedit",
-            "filenamePattern": "*.ini"
-        }
-    ],
+"workbench.editorAssociations": [
+  {
+    "viewType": "hexEditor.hexedit",
+    "filenamePattern": "*.hex"
+  },
+  {
+    "viewType": "hexEditor.hexedit",
+    "filenamePattern": "*.ini"
+  }
+],
 ```
-
-## Extension Settings
-
-This extension contributes the following settings:
-
-* `hexeditor.maxFileSize`: How many MB you want the editor to try to open before warning you with the open anyways message
 
 ## Known Issues
 
-- Undoing a pending edit causes editor to get into a bad state [161](https://github.com/microsoft/vscode-hexeditor/issues/161)
-- Searching in large files can become hit or miss [149](https://github.com/microsoft/vscode-hexeditor/issues/149)
+- Undoing a pending edit causes editor to get into a bad state [#161](https://github.com/microsoft/vscode-hexeditor/issues/161)
+- Searching in large files can become hit or miss [#149](https://github.com/microsoft/vscode-hexeditor/issues/149)
 
 To track all issues / file a new issue please go to the Github repo https://github.com/microsoft/vscode-hexeditor/issues
-
------------------------------------------------------------------------------------------------------------
-
-## Code of Conduct
-https://opensource.microsoft.com/codeofconduct

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "hexeditor",
 	"displayName": "Hex Editor",
-	"description": "Allows Hex Editing inside VS Code",
+	"description": "Allows viewing and editing files in a hex editor",
 	"version": "1.4.0",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",


### PR DESCRIPTION
Changes/justification:
- Removed header from top of readme as it re-states the title when viewing the
extension in marketplace/vscode
- Moved code of conduct to CODE_OF_CONDUCT.md, it's not relevant to people using
the extension
- Various wording improvements, made some sections more concise and removed
details that weren't important (eg. navigating/scrolling support)
- Moved easiest how to use steps to the top of the list
- Removed the contributed settings section as it repeats the contribution tab
within vscode

Fixes #221