### PR TITLE
Ensure the data inspector comes up blank on new editors

### DIFF
--- a/media/editor/hexEdit.ts
+++ b/media/editor/hexEdit.ts
@@ -4,6 +4,7 @@
 import { VirtualDocument } from "./virtualDocument";
 import { ChunkHandler } from "./chunkHandler";
 import { MessageHandler } from "./messageHandler";
+import { DataInspectorHandler } from "./dataInspectorHandler";
 
 declare const acquireVsCodeApi: any;
 export const vscode = acquireVsCodeApi();
@@ -29,6 +30,8 @@ function openAnyway(): void {
 		const { type, body } = e.data;
 		switch (type) {
 			case "init":
+				// Clear the data inspector when a new file is loaded
+				DataInspectorHandler.clearInspector();
 				// Loads the html body sent over
 				if (body.html !== undefined) {
 					document.getElementsByTagName("body")[0].innerHTML = body.html;

--- a/src/dataInspectorView.ts
+++ b/src/dataInspectorView.ts
@@ -66,10 +66,6 @@ export class DataInspectorView implements vscode.WebviewViewProvider {
 		} else {
 			vscode.commands.executeCommand(`${DataInspectorView.viewType}.focus`);
 		}
-		// We attempt to send the last message, this prevents the inspector from coming up blank
-		if (this._lastMessage) {
-			this._view?.webview.postMessage(this._lastMessage);
-		}
 	}
 
 	private _getWebviewHTML(webview: vscode.Webview): string {


### PR DESCRIPTION
Fixes #240

I removed a comment saying basically to do the opposite of the behavior I'm after. This problem was caused by old data from a previous focus from a previous document showing which was confusing when nothing was focused.