### PR TITLE
Keep utf-16 stable for most characters

### DIFF
--- a/dist/inspector.css
+++ b/dist/inspector.css
@@ -38,6 +38,10 @@ body {
 .grid-item:nth-child(2n) {
 	padding-left: 15px;
 	min-width: 100px; /* Prevent scroll bar unless really small */
+
+	/* Prevent special characters shifting the input around */
+	line-height: 1;
+	vertical-align: middle;
 }
 
 .header {


### PR DESCRIPTION
Fixes #130

This makes the inspector stable for almost all characters, I couldn't figure out how to deal with `ᬮ` in particular without resorting to `position:absolute` which feels hacky and not worth it.

![recording (11)](https://user-images.githubusercontent.com/2193314/111494721-f299a180-86fb-11eb-8314-33931824e8e4.gif)
