### PR TITLE
Remove data inspector header, improve panel name

### DIFF
--- a/dist/inspector.css
+++ b/dist/inspector.css
@@ -44,17 +44,6 @@ body {
 	vertical-align: middle;
 }
 
-.header {
-	position: sticky;
-	top: 0px;
-	font-weight: bold;
-	line-height: var(--vscode-editor-font-size);
-	color: var(--vscode-editorLineNumber-activeForeground);
-	z-index: 10;
-	border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border);
-	font-family: var(--vscode-font-family);
-}
-
 select {
 	background-color: var(--vscode-dropdown-background);
 	border: var(--vscode-dropdown-border);

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
 				{
 					"id": "hexExplorer",
 					"title": "Hex Editor",
-					"icon": "panel-icon.svg"
+					"icon": "panel-icon.svg",
+          "when": "hexEditor:openEditor"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -66,9 +66,8 @@
 			"activitybar": [
 				{
 					"id": "hexExplorer",
-					"title": "Hex Editor Panel",
-					"icon": "panel-icon.svg",
-					"when": "hexEditor:openEditor"
+					"title": "Hex Editor",
+					"icon": "panel-icon.svg"
 				}
 			]
 		},

--- a/src/dataInspectorView.ts
+++ b/src/dataInspectorView.ts
@@ -92,7 +92,6 @@ export class DataInspectorView implements vscode.WebviewViewProvider {
             </head>
             <body>
               <div id="data-inspector">
-              <div class="header">DATA INSPECTOR</div>
                 <div class="grid-container">
                   <div class="grid-item">
                     <label for="binary8">8 bit Binary</label>


### PR DESCRIPTION
Part of #132
Part of #223

What it looks like now:

<img width="377" alt="Screen Shot 2021-03-17 at 10 55 36 AM" src="https://user-images.githubusercontent.com/2193314/111514802-4feb1e00-870f-11eb-8bbf-0714035a1687.png">

Pulled into explorer:

<img width="378" alt="Screen Shot 2021-03-17 at 10 53 59 AM" src="https://user-images.githubusercontent.com/2193314/111514734-3fd33e80-870f-11eb-9d55-aaa2fb459b95.png">
