### PR TITLE
Add keybinding for gotoOffset

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,14 @@
           "when": "hexEditor:openEditor"
         }
       ]
-    }
+    },
+		"keybindings": [
+			{
+				"command": "hexEditor.goToOffset",
+				"key": "ctrl+g",
+				"when": "activeCustomEditorId == hexEditor.hexedit"
+			}
+		]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
You can't use the default Goto line command in the HexEditor. You get the message "Open a text editor first to go to a line."
Therefore I suggest overriding the default Goto keybinding while in the HexEditor with the gotoOffset command to get some utility back.

This also closes issue #212.
