### PR TITLE
feat: add copy/paste back in

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+	"editor.defaultFormatter": "vscode.typescript-language-features",
     "files.exclude": {
         "out": false // set this to true to hide the "out" folder with the compiled JS files
     },

--- a/media/editor/copyPaste.tsx
+++ b/media/editor/copyPaste.tsx
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license
+
+import { styled } from "@linaria/react";
+import * as base64 from "js-base64";
+import React, { useCallback, useMemo, useState } from "react";
+import { MessageType, PasteMode } from "../../shared/protocol";
+import { useUniqueId } from "./hooks";
+import { messageHandler } from "./state";
+import { VsButton, VsWidgetPopover } from "./vscodeUi";
+
+const enum Encoding {
+	Base64 = "base64",
+	Utf8 = "utf-8",
+}
+
+
+const encodings = [
+	Encoding.Utf8,
+	Encoding.Base64,
+];
+
+const encodingLabel: { [key in Encoding]: string } = {
+	[Encoding.Base64]: "Base64",
+	[Encoding.Utf8]: "UTF-8",
+};
+
+const isData: { [key in Encoding]: (data: string) => boolean } = {
+	[Encoding.Base64]: d => base64.isValid(d),
+	[Encoding.Utf8]: () => true,
+};
+
+const decode: { [key in Encoding]: (data: string) => Uint8Array } = {
+	[Encoding.Base64]: d => base64.toUint8Array(d),
+	[Encoding.Utf8]: d => new TextEncoder().encode(d),
+};
+
+const RadioList = styled.div`
+	display: flex;
+	margin-bottom: 12px;
+
+	> * {
+		margin-right: 8px;
+	}
+`;
+
+const RadioContainer = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const EncodingOption: React.FC<{
+	value: Encoding;
+	enabled: boolean;
+	checked: boolean;
+	onChecked: (encoding: Encoding) => void;
+}> = ({ value, enabled, checked, onChecked }) => {
+	const id = useUniqueId();
+	return <RadioContainer>
+		<input
+			id={id}
+			type="radio"
+			name="encoding"
+			disabled={!enabled}
+			value={value}
+			checked={checked}
+			onChange={evt => {
+				if (evt.target.checked) {
+					onChecked(value);
+				}
+			}}
+		/>
+		<label htmlFor={id}>{encodingLabel[value]}</label>
+	</RadioContainer>;
+};
+
+const InsertionOption: React.FC<{
+	value: PasteMode;
+	label: string;
+	checked: boolean;
+	onChecked: (encoding: PasteMode) => void;
+}> = ({ value, label, checked, onChecked }) => {
+	const id = useUniqueId();
+	return <RadioContainer>
+		<input
+			id={id}
+			type="radio"
+			name="insertMode"
+			value={value}
+			checked={checked}
+			onChange={evt => {
+				if (evt.target.checked) {
+					onChecked(value);
+				}
+			}}
+		/>
+		<label htmlFor={id}>{label}</label>
+	</RadioContainer>;
+};
+
+const ButtonWrap = styled.div`
+	display: flex;
+	width: 100%;
+	justify-content: center;
+`;
+
+export const PastePopup: React.FC<{
+	context?: { target: HTMLElement; data: string; offset: number; };
+	hide: () => void;
+}> = ({ context, hide }) => {
+	const [encoding, setEncoding] = useState(Encoding.Utf8);
+	const [mode, setMode] = useState(PasteMode.Replace);
+	const decoded: Uint8Array | Error = useMemo(() => {
+		try {
+			return context ? decode[encoding](context.data) : new Uint8Array();
+		} catch (e) {
+			return e as Error;
+		}
+	}, [context, encoding]);
+
+	const decodedValid = decoded instanceof Uint8Array;
+
+	const doReplace = useCallback(() => {
+		if (decoded instanceof Uint8Array && context) {
+			messageHandler.sendEvent({ type: MessageType.DoPaste, data: decoded, mode, offset: context.offset });
+			hide();
+		}
+	}, [decoded, mode, hide, context?.offset]);
+
+	return <VsWidgetPopover anchor={context?.target || null} hide={hide} visible={!!context}>
+		<RadioList>
+			<span>Paste as:</span>
+			{encodings.map(e => <EncodingOption
+				key={e}
+				value={e}
+				enabled={isData[e](context?.data || "")}
+				checked={e === encoding}
+				onChecked={setEncoding}
+				/>
+			)}
+		</RadioList>
+		<RadioList>
+			<span>Paste mode:</span>
+			<InsertionOption label="Replace" checked={mode == PasteMode.Replace} value={PasteMode.Replace} onChecked={setMode} />
+			<InsertionOption label="Insert" checked={mode == PasteMode.Insert} value={PasteMode.Insert} onChecked={setMode} />
+		</RadioList>
+		<ButtonWrap>
+			<VsButton disabled={!decodedValid} onClick={doReplace}>
+				{decodedValid
+					? <>{mode === PasteMode.Replace ? "Replace" : "Insert"} {decoded.length} bytes</>
+					: "Encoding Error"}
+				</VsButton>
+		</ButtonWrap>
+	</VsWidgetPopover>;
+};

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -13,7 +13,7 @@ import { useGlobalHandler, useLastAsyncRecoilValue } from "./hooks";
 import * as select from "./state";
 import { clamp, clsx, getAsciiCharacter, Range, RangeDirection } from "./util";
 
-	const Header = styled.div`
+const Header = styled.div`
 	font-weight: bold;
 	color: var(--vscode-editorLineNumber-activeForeground);
 `;
@@ -84,11 +84,11 @@ const dataDisplayCls = css`
 	height: 0px;
 `;
 
-export const DataHeader: React.FC= () => {
+export const DataHeader: React.FC = () => {
 	const editorSettings = useRecoilValue(select.editorSettings);
 
 	return <Header>
-		<DataCellGroup style={{ visibility: "hidden" }}  aria-hidden="true">
+		<DataCellGroup style={{ visibility: "hidden" }} aria-hidden="true">
 			<Address>00000000</Address>
 		</DataCellGroup>
 		<DataCellGroup>
@@ -247,7 +247,7 @@ export const DataDisplay: React.FC = () => {
 			return;
 		}
 
-    const pasteData = evt.clipboardData?.getData("text");
+		const pasteData = evt.clipboardData?.getData("text");
 		if (pasteData && ctx.focusedElement) {
 			setPasting({ target, offset: ctx.focusedElement.byte, data: pasteData });
 		}
@@ -382,6 +382,10 @@ const DataCell: React.FC<{
 	}, [byte]);
 
 	const onMouseDown = useCallback((e: React.MouseEvent) => {
+		if (!(e.buttons & 1)) {
+			return;
+		}
+
 		const prevFocused = ctx.focusedElement;
 		ctx.focusedElement = focusedElement;
 

--- a/media/editor/hooks.ts
+++ b/media/editor/hooks.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { DependencyList, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { RecoilValue, useRecoilValueLoadable } from "recoil";
 import { ColorMap, observeColors, parseColors } from "vscode-webview-tools";
 import { vscode } from "./state";
@@ -53,6 +53,11 @@ export const useOnChange = <T>(value: T, fn: (value: T, previous: T) => void): v
 	}, [value]);
 };
 
+let idCounter = 0;
+
+export const useUniqueId = (prefix = "uniqueid-"): string =>
+	useMemo(() => `${prefix}${idCounter++}`, [prefix]);
+
 const zeroRect: DOMRectReadOnly = new DOMRect();
 
 /** Uses the measured DOM size of the element, watching for resizes. */
@@ -100,4 +105,12 @@ export const useLastAsyncRecoilValue = <T>(value: RecoilValue<T>): [value: T, is
 	}
 
 	return [lastValue.current.value, lastValue.current.isStale];
+};
+
+export const useGlobalHandler = <T = Event>(name: string, handler: (evt: T) => void, deps: DependencyList = []) => {
+	useEffect(() => {
+		const l = (evt: Event) => handler(evt as unknown as T);
+		window.addEventListener(name, l);
+		return () => window.removeEventListener(name, l);
+	}, deps);
 };

--- a/media/editor/hooks.ts
+++ b/media/editor/hooks.ts
@@ -55,6 +55,7 @@ export const useOnChange = <T>(value: T, fn: (value: T, previous: T) => void): v
 
 let idCounter = 0;
 
+/** Creates a unique ID for use in the DOM */
 export const useUniqueId = (prefix = "uniqueid-"): string =>
 	useMemo(() => `${prefix}${idCounter++}`, [prefix]);
 

--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -46,7 +46,11 @@ export const showReadonlyWarningForEl = atom<HTMLElement | null>({
 
 export const fileSize = selector({
 	key: "fileSize",
-	get: ({ get }) => get(readyQuery).fileSize,
+	get: ({ get }) => {
+		const initial = get(readyQuery).fileSize;
+		const sizeDelta = get(editTimeline).sizeDelta;
+		return initial === undefined ? initial : initial + sizeDelta;
+	},
 });
 
 const initialOffset = selector<number>({

--- a/media/editor/vscodeUi.tsx
+++ b/media/editor/vscodeUi.tsx
@@ -118,8 +118,35 @@ export const VsProgressIndicator = styled.div`
 	}
 `;
 
-const iconButtonSize = 22;
+export const iconButtonSize = 22;
 const iconButtonMargin = 3;
+
+export const VsButton = styled.button`
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	border: 1px solid var(--vscode-button-border);
+	padding: 0 ${iconButtonMargin + iconButtonSize}px;
+	font-family: var(--vscode-font-family);
+	cursor: pointer;
+	padding: 6px 11px;
+
+	:hover {
+		background: var(--vscode-button-hoverBackground);
+	}
+
+	:active {
+		background: var(--vscode-button-background);
+	}
+
+	:focus {
+		outline: 1px solid var(--vscode-focusBorder);
+	}
+
+	:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+`;
 
 const VsIconButtonInner = styled.button`
 	background: transparent;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -27,6 +27,8 @@ export const enum MessageType {
 	ClearDataInspector,
 	SetInspectByte,
 	UpdateEditorSettings,
+	DoPaste,
+	DoCopy,
 	//#endregion
 }
 
@@ -173,6 +175,24 @@ export interface UpdateEditorSettings {
 	editorSettings: IEditorSettings;
 }
 
+export const enum PasteMode {
+	Insert = "insert",
+	Replace = "replace",
+}
+
+export interface PasteMessage {
+	type: MessageType.DoPaste;
+	offset: number;
+	data: Uint8Array;
+	mode: PasteMode;
+}
+
+export interface CopyMessage {
+	type: MessageType.DoCopy;
+	selections: [from: number, to: number][];
+	asText: boolean;
+}
+
 export type FromWebviewMessage =
 	| OpenDocumentMessage
 	| ReadRangeMessage
@@ -182,7 +202,9 @@ export type FromWebviewMessage =
 	| ClearDataInspectorMessage
 	| SetInspectByteMessage
 	| ReadyRequestMessage
-	| UpdateEditorSettings;
+	| UpdateEditorSettings
+	| PasteMessage
+	| CopyMessage;
 
 export type ExtensionHostMessageHandler = MessageHandler<ToWebviewMessage, FromWebviewMessage>;
 export type WebviewMessageHandler = MessageHandler<FromWebviewMessage, ToWebviewMessage>;

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
-import { HexDocumentEdit, HexDocumentEditReference, HexDocumentModel } from "../shared/hexDocumentModel";
+import { HexDocumentEdit, HexDocumentEditOp, HexDocumentEditReference, HexDocumentModel } from "../shared/hexDocumentModel";
 import { Backup } from "./backup";
 import { Disposable } from "./dispose";
 import { accessFile } from "./fileSystemAdaptor";
@@ -150,6 +150,29 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 	 */
 	public makeEdits(edits: readonly HexDocumentEdit[]): HexDocumentEditReference {
 		return this.model.makeEdits(edits);
+	}
+
+	/**
+	 * Inserts data into the document.
+	 */
+	public insert(offset: number, data: Uint8Array): HexDocumentEditReference {
+		return this.model.makeEdits([{ op: HexDocumentEditOp.Insert, offset, value: data }]);
+	}
+
+	/**
+	 * Replaces data into the document. If the data is larger than the document,
+	 * then this results in the necessary additional insertion operation.
+	 */
+	public async replace(offset: number, data: Uint8Array): Promise<HexDocumentEditReference> {
+		const previous = await this.readBufferWithEdits(offset, data.length);
+		if (previous.length === data.length) {
+			return this.makeEdits([{ op: HexDocumentEditOp.Replace, offset, value: data, previous }]);
+		} else {
+			return this.makeEdits([
+				{ op: HexDocumentEditOp.Replace, offset: offset, value: data.subarray(0, previous.length), previous },
+				{ op: HexDocumentEditOp.Insert, offset: offset + previous.length, value: data.subarray(previous.length) },
+			]);
+		}
 	}
 
 	/**

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,3 +41,19 @@ export const utf8Length = (str: string): number => {
 	return new Blob([str]).size;
 	}
 };
+
+export const flattenBuffers = (buffers: readonly Uint8Array[]): Uint8Array => {
+	let size = 0;
+	for (const buffer of buffers) {
+		size += buffer.byteLength;
+	}
+
+	const target = new Uint8Array(size);
+	let offset = 0;
+	for (const buffer of buffers) {
+		target.set(buffer, offset);
+		offset += buffer.byteLength;
+	}
+
+	return target;
+};


### PR DESCRIPTION
Quick version of copy/paste. Pasting brings up the following dialog:

![image](https://user-images.githubusercontent.com/2230985/151241545-63b9b068-62df-4a29-862c-7dd52c5e49b7.png)

Copying will copy the base64 version if the binary side is selected, or the utf-8 version of the text if the text side is selected.

Also, there were some changes in the `fileSystemAdaptor.ts`. I realized that inserting certain text could lead to an infinite loop (and infinite size) when writing a file, since instructions to read content from the file could read newly written text and cause it to keep duplicating. To fix this, I modified the native filesystem adapter so that (if a file needs to be written, i.e. if there was a length change) it writes to a temp file and is renamed. As referenced in the comment, this should have minimal performance impact. I realized this also fixes an issue where files couldn't be shrunk shorter than they used to be.

Fixes https://github.com/microsoft/vscode-hexeditor/issues/333
