### PR TITLE
feat: add binary type to data inspector properties

### DIFF
--- a/media/editor/dataInspectorProperties.tsx
+++ b/media/editor/dataInspectorProperties.tsx
@@ -14,6 +14,8 @@ export interface IInspectableType {
 }
 
 export const inspectableTypes: readonly IInspectableType[] = [
+	{ label: "binary", minBytes: 1, convert: dv => dv.getUint8(0).toString(2).padStart(8, "0") },
+
 	{ label: "uint8", minBytes: 1, convert: dv => dv.getUint8(0).toString() },
 	{ label: "int8", minBytes: 1, convert: dv => dv.getInt8(0).toString() },
 


### PR DESCRIPTION
This adds the binary representation of the selected value to the data inspector properties. This property is especially useful for analyzing bit fields and non-standard types. Here's a screenshot of what it looks like:
![Capture](https://user-images.githubusercontent.com/47087725/181823633-338181a6-dca3-4903-861e-e4294a28ebd9.PNG)
