### PR TITLE
docs: fix inconsistencies in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Manage any merge conflicts, commit them, and then push them to your fork.
 
 ## Prerequisites
 
-In order to download necessary tools, clone the repository, and install dependencies via `yarn` you need network access.
+In order to download necessary tools, clone the repository, and install dependencies through npm, you need network access.
 
 You'll need the following tools:
 
@@ -38,7 +38,7 @@ npm install
 
 ## Build and Run
 
-After cloning the extension and running `npm install` execute `npm run webpack-watch` to initiate webpack's file watcher and then use the debugger in VS Code to execute "Run Extension".
+After cloning the extension and running `npm install` execute `npm run watch` to initiate esbuild's file watcher and then use the debugger in VS Code to execute "Run Extension".
 
 ### Linting
 We use [eslint](https://eslint.org/) for linting our sources. You can run eslint across the sources by calling `npm run lint` from a terminal or command prompt.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The hex editor can be set as the default editor for certain file types by using 
 
 ## Configuring the Data Inspector
 
-By default the data inspector has a dedicated activity bar entry on the left that appears when the hex editor is opened, causing the explorer or whatever side bar you had opened to be hidden. If preferred, the hex editor view can be dragged into another view by dragging the ⬡ icon onto one of the other views.
+By default, the data inspector is shown just to the right of the data grid (or decoded text if enabled), but it can be configured (via the `hexeditor.inspectorType` setting) to instead show up while hovering over a data cell.
 
-This can be used in combination with the `hexeditor.dataInspector.autoReveal` setting to avoid revealing the side bar containing the data inspector all together.
+Another option is to give the data inspector a dedicated activity bar entry on the left (by setting `hexeditor.inspectorType` to `sidebar`) that appears when the hex editor is opened, causing the explorer or whatever sidebar you had opened to be hidden. If preferred, the hex editor view can be dragged into another view by dragging the ⬡ icon onto one of the other views. This can be used in combination with the `hexeditor.dataInspector.autoReveal` setting to avoid revealing the sidebar containing the data inspector altogether.
 
 ## Known Issues
 


### PR DESCRIPTION
While contributing, I noticed some outdated documentation:
- yarn is no longer used.
- esbuild is now used instead of webpack.
- The data inspector has three different setups with `aside` being the new default.