### PR TITLE
Add Hex Editor button to editor/title menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "commands": [
       {
         "command": "hexEditor.openFile",
-        "title": "Hex Editor: Open Active File in Hex Editor"
+        "title": "Hex Editor: Open Active File in Hex Editor",
+        "icon": "$(file-binary)"
       },
       {
         "command": "hexEditor.goToOffset",
@@ -130,6 +131,13 @@
         {
           "command": "hexEditor.goToOffset",
           "when": "hexEditor:isActive"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "activeEditor",
+          "command": "hexEditor.openFile",
+          "group": "navigation@1"
         }
       ]
     },


### PR DESCRIPTION
Add very useful button to open hex editor for opened file.

![image](https://user-images.githubusercontent.com/8218016/185716449-b5b28ec6-0bf9-49e4-9683-86f6df6d8cd5.png)

Just switched from an old extenstion to this one by `merge` option in extension panel. And didn't found any button, to easy view hex code for opened file.