### PR TITLE
[WIP] feat: simple hex data colorization

### DIFF
--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -522,6 +522,13 @@ const DataCell: React.FC<{
 			onMouseLeave={onMouseLeave}
 			onKeyDown={onKeyDown}
 			data-key={focusedElement.key}
+			style={isChar ? {} : {
+				backgroundColor: `rgba(\
+					${(((value & 0xe0) >> 5) / ((1 << 3) - 1) * 0xff) | 0},\
+					${(((value & 0x1c) >> 2) / ((1 << 3) - 1) * 0xff) | 0},\
+					${((value & 0x3) / ((1 << 2) - 1) * 0xff) | 0},\
+					0.5)`
+			}}
 		>{firstOctetOfEdit !== undefined
 			? firstOctetOfEdit.toString(16).toUpperCase()
 			: children}</span>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8456460/191026842-e6fbd987-1f9a-48cf-a7b8-b2b59b89d01a.png)

Colorize hex data by treating each byte as an 8-bit color (3, 3, 2 bits for R, G and B). I find it useful visualizing binary data with unknown format.

Also an implementation on #279, although using RGB instead of HSL, and the alpha is currently fixed at 0.5.

If this feature is desirable, options to toggle it and change the alpha value and even palettes can be added in the future.