### PR TITLE
fix: use a smaller page size for debug memory

### DIFF
--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -188,9 +188,9 @@ export const offset = atom({
 });
 
 /** Size of data pages, in bytes */
-export const dataPageSize = atom({
+export const dataPageSize = selector({
 	key: "dataPageSize",
-	default: 128 * 1024
+	get: ({ get }) => get(readyQuery).pageSize,
 });
 
 /**

--- a/shared/fileAccessor.ts
+++ b/shared/fileAccessor.ts
@@ -22,6 +22,11 @@ export interface FileAccessor {
 	 */
 	readonly isReadonly?: boolean;
 
+	/**
+	 * Preferred page size of the accessor.
+	 */
+	readonly pageSize: number;
+
 	/** Implements a file watcher. */
 	watch(onDidChange: () => void, onDidDelete: () => void): vscode.Disposable;
 	/** Calculates the size of the associated document. Undefined if unbounded */

--- a/shared/hexDocumentModel.ts
+++ b/shared/hexDocumentModel.ts
@@ -87,6 +87,7 @@ export interface IEditTimeline {
 export class HexDocumentModel {
 	public readonly supportsLengthChanges: boolean;
 	public readonly isFiniteSize: boolean;
+	public readonly pageSize: number;
 	private readonly accessor: FileAccessor;
 	/** Guard to make sure only one save operation happens at a time */
 	private readonly saveGuard = Policy.bulkhead(1, Infinity);
@@ -100,6 +101,7 @@ export class HexDocumentModel {
 		this.supportsLengthChanges = options.supportsLengthChanges;
 		this.isFiniteSize = options.isFiniteSize;
 		this.accessor = options.accessor;
+		this.pageSize = options.accessor.pageSize;
 	}
 
 	/**

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -59,6 +59,7 @@ export interface IEditorSettings {
 export interface ReadyResponseMessage {
 	type: MessageType.ReadyResponse;
 	initialOffset: number;
+	pageSize: number;
 	edits: ISerializedEdits;
 	editorSettings: IEditorSettings;
 	unsavedEditIndex: number;

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -57,6 +57,13 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 	}
 
 	/**
+	 * Gets the preferred page size of the document.
+	 */
+	public get pageSize() {
+		return this.model.pageSize;
+	}
+
+	/**
 	 * Gets whether the model is read-only.
 	 */
 	public get isReadonly(): boolean {

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -253,6 +253,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 					edits: serializeEdits(document.edits),
 					unsavedEditIndex: document.unsavedEditIndex,
 					fileSize: await document.size(),
+					pageSize: document.pageSize,
 					isLargeFile: document.isLargeFile,
 					isReadonly: document.isReadonly,
 				};


### PR DESCRIPTION
Effectively resolves https://github.com/microsoft/debug-adapter-protocol/issues/322

It seems the default of 128KB is too much for many embedded DA's to be able
to serve in a satisfactory way.

Also, it seems that paging debug data wasn't working before. Whoops.
Fixed that as well.