### PR TITLE
fix: accumulate scroll delta for better trackpad scrolling

### DIFF
--- a/media/editor/scrollContainer.tsx
+++ b/media/editor/scrollContainer.tsx
@@ -1,9 +1,9 @@
 import { css } from "@linaria/core";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
+import { DataDisplay } from "./dataDisplay";
 import * as select from "./state";
 import { Range } from "./util";
-import { DataDisplay } from "./dataDisplay";
 import { VirtualScrollContainer } from "./virtualScrollContainer";
 
 const wrapperCls = css`
@@ -53,9 +53,15 @@ export const ScrollContainer: React.FC = () => {
 		setScrollTop(dimension.rowPxHeight * (offset / columnWidth));
 	}, [offset]);
 
+	// If scrolling slowly, an individual scroll event might not be able to move
+	// to a new offset. This stores the "unused" scroll amount.
+	const accumulatedScroll = useRef(0);
+
 	const onScroll = useCallback((scrollTop: number) => {
 		// On scroll, figure out the offset displayed at the new position.
+		scrollTop += accumulatedScroll.current;
 		const rowNumber = Math.floor(scrollTop / dimension.rowPxHeight);
+		accumulatedScroll.current = scrollTop - (rowNumber * dimension.rowPxHeight);
 		const newOffset = rowNumber * columnWidth;
 		const newScrollTop = rowNumber * dimension.rowPxHeight;
 		previousOffset.current = newOffset;


### PR DESCRIPTION
There were a couple issues around scroll, this makes it feel more native: we only actually scroll to full rows, but if there's unused scroll delta that doesn't get us all the way to the next row, use that in the next event.