### PR TITLE
fix: update scroll size when underlying file size changes

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -105,6 +105,7 @@ export interface ReloadMessage {
 export interface SetEditsMessage {
 	type: MessageType.SetEdits;
 	edits: ISerializedEdits;
+	replaceFileSize?: number | null;
 }
 
 /** Sets the displayed offset. */
@@ -233,7 +234,7 @@ export class MessageHandler<TTo, TFrom> {
 	constructor(
 		public messageHandler: (msg: TFrom) => Promise<TTo | undefined>,
 		private readonly postMessage: (msg: WebviewMessage<TTo>) => void,
-	) {}
+	) { }
 
 	/** Sends a request without waiting for a response */
 	public sendEvent(body: TTo): void {

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -55,9 +55,10 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 		const { document, accessor } = await HexDocument.create(uri, openContext, this._telemetryReporter);
 		const disposables: vscode.Disposable[] = [];
 
-		disposables.push(document.onDidRevert(() => {
+		disposables.push(document.onDidRevert(async () => {
+			const replaceFileSize = await document.size() ?? null;
 			for (const { messaging } of this.webviews.get(document.uri)) {
-				messaging.sendEvent({ type: MessageType.SetEdits, edits: { edits: [], data: new Uint8Array() } });
+				messaging.sendEvent({ type: MessageType.SetEdits, edits: { edits: [], data: new Uint8Array() }, replaceFileSize });
 				messaging.sendEvent({ type: MessageType.ReloadFromDisk });
 			}
 		}));


### PR DESCRIPTION
Fixes #119

Mostly making multiple things being able to listen to renderer events.