### PR TITLE
refactor: get a 45% performance boost

### DIFF
--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -228,7 +228,13 @@ export const offset = atom({
 /** Size of data pages, in bytes */
 export const dataPageSize = selector({
 	key: "dataPageSize",
-	get: ({ get }) => get(readyQuery).pageSize,
+	get: ({ get }) => {
+		const colWidth = get(columnWidth);
+		const pageSize = get(readyQuery).pageSize;
+		// Make sure the page size is a multiple of column width, since rendering
+		// happens in page chunks.
+		return Math.round(pageSize / colWidth) * colWidth;
+	}
 });
 
 /**


### PR DESCRIPTION
Some small weekend tweaks.

This moves data retrieval from data rows into data pages. I noticed a bunch of time was spent negotiating data retrieval inside each `<DataRowContents />`, so this improves that by making it happen in one (or, if the user is on a boundary, two) places instead of 30+. This net about a 30% boost over the original 'new page' render time.

I also moved the DOM structure to be based on DataPages that are in layers and moved as a group instead of inidivudally. This net an additional 15% improvement over the original 'new page' time.

Cost to render a new page before:

![](https://memes.peet.io/img/22-12-6eab495d-1008-4eee-a9e5-eb90233b723e.png)

after:

![](https://memes.peet.io/img/22-12-0df37399-2450-4631-9b25-e3fb91dccb9c.png)