### PR TITLE
Add octal representation of the current byte in data inspector

### DIFF
--- a/media/editor/dataInspectorProperties.tsx
+++ b/media/editor/dataInspectorProperties.tsx
@@ -16,6 +16,8 @@ export interface IInspectableType {
 export const inspectableTypes: readonly IInspectableType[] = [
 	{ label: "binary", minBytes: 1, convert: dv => dv.getUint8(0).toString(2).padStart(8, "0") },
 
+	{ label: "octal", minBytes: 1, convert: dv => dv.getUint8(0).toString(8).padStart(3, "0") },
+
 	{ label: "uint8", minBytes: 1, convert: dv => dv.getUint8(0).toString() },
 	{ label: "int8", minBytes: 1, convert: dv => dv.getInt8(0).toString() },
 


### PR DESCRIPTION
Realised I could add this myself re: #405 