### PR TITLE
Remove implicit activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,6 @@
     "Other"
   ],
   "icon": "icon.png",
-  "activationEvents": [
-    "onView:hexEditor.dataInspectorView",
-    "onCustomEditor:hexEditor.hexedit",
-    "onCommand:hexEditor.openFile"
-  ],
   "main": "./dist/extension.js",
   "browser": "./dist/web/extension.js",
   "capabilities": {


### PR DESCRIPTION
Now that VS Code implicitly registers many activation events, we don't need these