### PR TITLE
fix: scroll to the top when hit home key

### DIFF
--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -97,7 +97,7 @@ export const DataDisplay: React.FC = () => {
 	// When the focused byte changes, make sure it's in view
 	useEffect(() => {
 		const disposable = ctx.onDidChangeAnyFocus(byte => {
-			if (!byte) {
+			if (byte === undefined) {
 				return;
 			}
 


### PR DESCRIPTION
Fix #425. The issue was due to the fact that `onDidChangeAnyFocus` returned immediately if the focused byte was 0.