### PR TITLE
Select between offsets

### DIFF
--- a/media/editor/dataDisplayContext.tsx
+++ b/media/editor/dataDisplayContext.tsx
@@ -218,6 +218,15 @@ export class DisplayContext {
 			this.setSelectionRanges([Range.single(msg.offset)]);
 		});
 
+		registerHandler(MessageType.SetFocusedByteRange, msg => {
+			if (!document.hasFocus()) {
+				window.focus();
+			}
+
+			this.focusedElement = new FocusedElement(false, msg.startingOffset);
+			this.setSelectionRanges([Range.inclusive(msg.startingOffset, msg.endingOffset)]);
+		});
+
 		this.selectionChangeEmitter.addListener(() => this.publishSelections());
 	}
 

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
         "title": "Hex Editor: Go To Offset"
       },
       {
-        "command": "hexEditor.selectUntilOffset",
-        "title": "Hex Editor: Select Until Offset"
+        "command": "hexEditor.selectBetweenOffsets",
+        "title": "Hex Editor: Select Between Offsets"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
       {
         "command": "hexEditor.goToOffset",
         "title": "Hex Editor: Go To Offset"
+      },
+      {
+        "command": "hexEditor.selectUntilOffset",
+        "title": "Hex Editor: Select Until Offset"
       }
     ],
     "viewsContainers": {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -15,6 +15,7 @@ export const enum MessageType {
 	StashDisplayedOffset,
 	GoToOffset,
 	SetFocusedByte,
+	SetFocusedByteRange,
 	SetSelectedCount,
 	PopDisplayedOffset,
 	//#endregion
@@ -126,6 +127,13 @@ export interface SetFocusedByteMessage {
 	offset: number;
 }
 
+/** Focuses a byte range in the editor. */
+export interface SetFocusedByteRangeMessage {
+	type: MessageType.SetFocusedByteRange;
+	startingOffset: number;
+	endingOffset: number;
+}
+
 /** sets the count of selected bytes. */
 export interface SetSelectedCountMessage {
 	type: MessageType.SetSelectedCount;
@@ -152,6 +160,7 @@ export type ToWebviewMessage =
 	| GoToOffsetMessage
 	| SetEditsMessage
 	| SetFocusedByteMessage
+	| SetFocusedByteRangeMessage
 	| PopDisplayedOffsetMessage
 	| StashDisplayedOffsetMessage;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { DataInspectorView } from "./dataInspectorView";
 import { showGoToOffset } from "./goToOffset";
 import { HexEditorProvider } from "./hexEditorProvider";
 import { HexEditorRegistry } from "./hexEditorRegistry";
-import { showSelectUntilOffset } from "./selectUntilOffset";
+import { showSelectBetweenOffsets } from "./selectBetweenOffsets";
 import StatusSelectionCount from "./statusSelectionCount";
 
 function readConfigFromPackageJson(extension: vscode.Extension<any>): { extId: string; version: string; aiKey: string } {
@@ -46,15 +46,15 @@ export function activate(context: vscode.ExtensionContext): void {
 			showGoToOffset(first.value);
 		}
 	});
-	const selectUntilOffsetCommand = vscode.commands.registerCommand("hexEditor.selectUntilOffset", () => {
+	const selectBetweenOffsetsCommand = vscode.commands.registerCommand("hexEditor.selectBetweenOffsets", () => {
 		const first = registry.activeMessaging[Symbol.iterator]().next();
 		if (first.value) {
-			showSelectUntilOffset(first.value);
+			showSelectBetweenOffsets(first.value);
 		}
 	});
 	context.subscriptions.push(new StatusSelectionCount(registry));
 	context.subscriptions.push(goToOffsetCommand);
-	context.subscriptions.push(selectUntilOffsetCommand);
+	context.subscriptions.push(selectBetweenOffsetsCommand);
 	context.subscriptions.push(openWithCommand);
 	context.subscriptions.push(telemetryReporter);
 	context.subscriptions.push(HexEditorProvider.register(context, telemetryReporter, dataInspectorProvider, registry));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	const selectBetweenOffsetsCommand = vscode.commands.registerCommand("hexEditor.selectBetweenOffsets", () => {
 		const first = registry.activeMessaging[Symbol.iterator]().next();
 		if (first.value) {
-			showSelectBetweenOffsets(first.value);
+			showSelectBetweenOffsets(first.value, registry);
 		}
 	});
 	context.subscriptions.push(new StatusSelectionCount(registry));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { DataInspectorView } from "./dataInspectorView";
 import { showGoToOffset } from "./goToOffset";
 import { HexEditorProvider } from "./hexEditorProvider";
 import { HexEditorRegistry } from "./hexEditorRegistry";
+import { showSelectUntilOffset } from "./selectUntilOffset";
 import StatusSelectionCount from "./statusSelectionCount";
 
 function readConfigFromPackageJson(extension: vscode.Extension<any>): { extId: string; version: string; aiKey: string } {
@@ -45,8 +46,15 @@ export function activate(context: vscode.ExtensionContext): void {
 			showGoToOffset(first.value);
 		}
 	});
+	const selectUntilOffsetCommand = vscode.commands.registerCommand("hexEditor.selectUntilOffset", () => {
+		const first = registry.activeMessaging[Symbol.iterator]().next();
+		if (first.value) {
+			showSelectUntilOffset(first.value);
+		}
+	});
 	context.subscriptions.push(new StatusSelectionCount(registry));
 	context.subscriptions.push(goToOffsetCommand);
+	context.subscriptions.push(selectUntilOffsetCommand);
 	context.subscriptions.push(openWithCommand);
 	context.subscriptions.push(telemetryReporter);
 	context.subscriptions.push(HexEditorProvider.register(context, telemetryReporter, dataInspectorProvider, registry));

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -18,8 +18,6 @@ export interface ISelectionState {
 }
 
 export class HexDocument extends Disposable implements vscode.CustomDocument {
-	static currentHexDocument: HexDocument | undefined;
-
 	static async create(
 		uri: vscode.Uri,
 		{ backupId, untitledDocumentData }: vscode.CustomDocumentOpenContext,
@@ -48,8 +46,7 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 
 		const maxFileSize = (vscode.workspace.getConfiguration().get("hexeditor.maxFileSize") as number) * 1000000;
 		const isLargeFile = !backupId && !accessor.supportsIncremetalAccess && ((fileSize ?? 0) > maxFileSize);
-		this.currentHexDocument = new HexDocument(model, isLargeFile, baseAddress);
-		return { document: this.currentHexDocument, accessor };
+		return { document: new HexDocument(model, isLargeFile, baseAddress), accessor };
 	}
 
 	// Last save time

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -18,6 +18,8 @@ export interface ISelectionState {
 }
 
 export class HexDocument extends Disposable implements vscode.CustomDocument {
+	static currentHexDocument: HexDocument | undefined;
+
 	static async create(
 		uri: vscode.Uri,
 		{ backupId, untitledDocumentData }: vscode.CustomDocumentOpenContext,
@@ -46,7 +48,8 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 
 		const maxFileSize = (vscode.workspace.getConfiguration().get("hexeditor.maxFileSize") as number) * 1000000;
 		const isLargeFile = !backupId && !accessor.supportsIncremetalAccess && ((fileSize ?? 0) > maxFileSize);
-		return { document: new HexDocument(model, isLargeFile, baseAddress), accessor };
+		this.currentHexDocument = new HexDocument(model, isLargeFile, baseAddress);
+		return { document: this.currentHexDocument, accessor };
 	}
 
 	// Last save time

--- a/src/selectBetweenOffsets.ts
+++ b/src/selectBetweenOffsets.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
 import { ExtensionHostMessageHandler, MessageType } from "../shared/protocol";
-import { HexDocument, ISelectionState } from "./hexDocument";
+import { ISelectionState } from "./hexDocument";
+import { HexEditorRegistry } from "./hexEditorRegistry";
 
 const addressRe = /^0x[a-f0-9]+$/i;
 const decimalRe = /^[0-9]+$/i;
 
-export const showSelectBetweenOffsets = (messaging: ExtensionHostMessageHandler): void => {
+export const showSelectBetweenOffsets = (messaging: ExtensionHostMessageHandler, registry: HexEditorRegistry): void => {
     const startingInput = vscode.window.createInputBox();
     const endingInput = vscode.window.createInputBox();
     startingInput.placeholder = "Enter offset to select from";
@@ -18,8 +19,8 @@ export const showSelectBetweenOffsets = (messaging: ExtensionHostMessageHandler)
     let toOffset: number | undefined;
     let accepted = false;
 
-    // acquire selection state from current HexDocument
-    const selectionState: ISelectionState | undefined = HexDocument.currentHexDocument?.selectionState;
+    // acquire selection state from active HexDocument
+    const selectionState: ISelectionState | undefined = registry.activeDocument?.selectionState;
 
     // if there is a selection, use the focused offset as the starting offset
     if (selectionState !== undefined && selectionState.selected > 0 && selectionState.focused !== undefined) {

--- a/src/selectBetweenOffsets.ts
+++ b/src/selectBetweenOffsets.ts
@@ -4,7 +4,7 @@ import { ExtensionHostMessageHandler, MessageType } from "../shared/protocol";
 const addressRe = /^0x[a-f0-9]+$/i;
 const decimalRe = /^[0-9]+$/i;
 
-export const showSelectUntilOffset = (messaging: ExtensionHostMessageHandler): void => {
+export const showSelectBetweenOffsets = (messaging: ExtensionHostMessageHandler): void => {
     const startingInput = vscode.window.createInputBox();
     const endingInput = vscode.window.createInputBox();
     startingInput.placeholder = "Enter offset to select from";

--- a/src/selectBetweenOffsets.ts
+++ b/src/selectBetweenOffsets.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { ExtensionHostMessageHandler, MessageType } from "../shared/protocol";
+import { HexDocument, ISelectionState } from "./hexDocument";
 
 const addressRe = /^0x[a-f0-9]+$/i;
 const decimalRe = /^[0-9]+$/i;
@@ -15,6 +16,16 @@ export const showSelectBetweenOffsets = (messaging: ExtensionHostMessageHandler)
     let fromOffset: number | undefined;
     let toOffset: number | undefined;
     let accepted = false;
+
+    // acquire selection state from current HexDocument
+    const selectionState: ISelectionState | undefined = HexDocument.currentHexDocument?.selectionState;
+
+    // if there is a selection, use the focused offset as the starting offset
+    if (selectionState !== undefined && selectionState.selected > 0 && selectionState.focused !== undefined) {
+        fromOffset = selectionState.focused;
+        // converting to hex to increase readability
+        startingInput.value = `0x${fromOffset.toString(16)}`;
+    }
 
     startingInput.onDidChangeValue(value => {
         if (!value) {

--- a/src/selectUntilOffset.ts
+++ b/src/selectUntilOffset.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode";
+import { ExtensionHostMessageHandler, MessageType } from "../shared/protocol";
+
+const addressRe = /^0x[a-f0-9]+$/i;
+const decimalRe = /^[0-9]+$/i;
+
+export const showSelectUntilOffset = (messaging: ExtensionHostMessageHandler): void => {
+    const startingInput = vscode.window.createInputBox();
+    const endingInput = vscode.window.createInputBox();
+    startingInput.placeholder = "Enter offset to select from";
+    endingInput.placeholder = "Enter offset to select until";
+
+    messaging.sendEvent({ type: MessageType.StashDisplayedOffset });
+
+    let fromOffset: number | undefined;
+    let toOffset: number | undefined;
+    let accepted = false;
+
+    startingInput.onDidChangeValue(value => {
+        if (!value) {
+            fromOffset = undefined;
+        } else if (addressRe.test(value)) {
+            fromOffset = parseInt(value.slice(2), 16);
+        } else if (decimalRe.test(value)) {
+            fromOffset = parseInt(value, 10);
+        } else {
+            startingInput.validationMessage = "Offset must be provided as a decimal (12345) or hex (0x12345) address";
+            return;
+        }
+
+        startingInput.validationMessage = "";
+        if (fromOffset !== undefined) {
+            startingInput.validationMessage = "";
+            messaging.sendEvent({ type: MessageType.GoToOffset, offset: fromOffset });
+        }
+    });
+
+    startingInput.onDidAccept(() => {
+        if (fromOffset !== undefined) {
+            endingInput.show();
+        }
+    });
+
+    startingInput.onDidHide(() => {
+        if (!accepted) {
+            messaging.sendEvent({ type: MessageType.PopDisplayedOffset });
+        }
+    });
+
+    endingInput.onDidChangeValue(value => {
+        if (!value) {
+            toOffset = undefined;
+        } else if (addressRe.test(value)) {
+            toOffset = parseInt(value.slice(2), 16);
+        } else if (decimalRe.test(value)) {
+            toOffset = parseInt(value, 10);
+        } else {
+            startingInput.validationMessage = "Offset must be provided as a decimal (12345) or hex (0x12345) address";
+            return;
+        }
+
+        startingInput.validationMessage = "";
+        if (toOffset !== undefined) {
+            startingInput.validationMessage = "";
+            messaging.sendEvent({ type: MessageType.GoToOffset, offset: toOffset });
+        }
+    });
+
+    endingInput.onDidAccept(() => {
+        accepted = true;
+        if (fromOffset !== undefined && toOffset !== undefined) {
+            messaging.sendEvent({ type: MessageType.SetFocusedByteRange, startingOffset: fromOffset, endingOffset: toOffset });
+        }
+    });
+
+    endingInput.onDidHide(() => {
+        if (!accepted) {
+            messaging.sendEvent({ type: MessageType.PopDisplayedOffset });
+        }
+    });
+
+    startingInput.show();
+};


### PR DESCRIPTION
Implements a simple command that enables user to select byte values between 2 offsets.
Useful for extracting embedded files. 

closes #469 