### PR TITLE
Fixes wrong font-size var

### DIFF
--- a/media/editor/hexEdit.css
+++ b/media/editor/hexEdit.css
@@ -8,6 +8,7 @@
 :global(body) {
 	margin: 0;
 	padding: 0;
+	font-size: var(--vscode-editor-font-size);
 }
 
 :global(html) {

--- a/media/editor/hexEdit.tsx
+++ b/media/editor/hexEdit.tsx
@@ -30,7 +30,7 @@ const Root: React.FC = () => {
 			setDimensions({
 				width: window.innerWidth,
 				height: window.innerHeight,
-				rowPxHeight: parseInt(theme["font-size"]) + 8,
+				rowPxHeight: parseInt(theme["editor-font-size"]) + 8,
 			});
 
 		window.addEventListener("resize", applyDimensions);


### PR DESCRIPTION
Instead of using the default font-size, uses the editor's font-size.

Closes #504 