### PR TITLE
Fix swapped entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 1.10.0 - April 22, 2024
 
-- Add insert mode, thanks to [@tomilho via #513](https://github.com/microsoft/vscode-hexeditor/pull/513)
+- Fix bug in saving of restored editors, thanks to [@tomilho via #513](https://github.com/microsoft/vscode-hexeditor/pull/513)
 - Add hovered byte status bar entry [@tomilho via #502](https://github.com/microsoft/vscode-hexeditor/pull/502)
-- Fix bug in saving of restored editors [@tomilho via #503](https://github.com/microsoft/vscode-hexeditor/pull/503)
+- Add insert mode [@tomilho via #503](https://github.com/microsoft/vscode-hexeditor/pull/503)
 
 ## 1.9.14 - February 22, 2024
 - Add ULEB128 and SLEB128 support in data inspector, thanks to [@jogo- via #488](https://github.com/microsoft/vscode-hexeditor/pull/488)


### PR DESCRIPTION
When checking the release, I noticed that the CHANGELOG entries are incorrect