### PR TITLE
HexEditor diff 

### DIFF
--- a/.esbuild.config.js
+++ b/.esbuild.config.js
@@ -46,7 +46,7 @@ build({
 	tsconfig: "./tsconfig.json",
 	bundle: true,
 	format: "cjs",
-	external: ["vscode", "fs"],
+	external: ["vscode", "fs", "worker_threads"],
 	minify,
 	platform: "browser",
 	outfile: "dist/web/extension.js",
@@ -57,10 +57,10 @@ build({
 	tsconfig: "./tsconfig.json",
 	bundle: true,
 	format: "cjs",
-	external: ["vscode"],
+	external: ["vscode", "worker_threads"],
 	minify,
 	platform: "browser",
-	outfile: "dist/web/diffWorker.js",
+	outfile: "dist/diffWorker.js",
 });
 
 // Build the data inspector

--- a/.esbuild.config.js
+++ b/.esbuild.config.js
@@ -52,6 +52,17 @@ build({
 	outfile: "dist/web/extension.js",
 });
 
+build({
+	entryPoints: ["shared/diffWorker.ts"],
+	tsconfig: "./tsconfig.json",
+	bundle: true,
+	format: "cjs",
+	external: ["vscode"],
+	minify,
+	platform: "browser",
+	outfile: "dist/web/diffWorker.js",
+});
+
 // Build the data inspector
 build({
 	entryPoints: ["media/data_inspector/inspector.ts"],

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -704,7 +704,7 @@ const DataRowContents: React.FC<{
 	const { bytes, chars } = useMemo(() => {
 		const bytes: React.ReactChild[] = [];
 		const chars: React.ReactChild[] = [];
-		const searcher = binarySearch<HexDecorator>(r => r.range.start);
+		const searcher = binarySearch<HexDecorator>(d => d.range.end);
 		let j = searcher(offset, decorators);
 		for (let i = 0; i < width; i++) {
 			const boffset = offset + i;

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -36,6 +36,7 @@ import {
 	parseHexDigit,
 	throwOnUndefinedAccessInDev,
 } from "./util";
+import { binarySearch } from "../../shared/util/binarySearch";
 
 const style = throwOnUndefinedAccessInDev(_style);
 
@@ -703,7 +704,8 @@ const DataRowContents: React.FC<{
 	const { bytes, chars } = useMemo(() => {
 		const bytes: React.ReactChild[] = [];
 		const chars: React.ReactChild[] = [];
-		let j = 0;
+		const searcher = binarySearch<HexDecorator>(r => r.range.start);
+		let j = searcher(offset, decorators);
 		for (let i = 0; i < width; i++) {
 			const boffset = offset + i;
 			const value = rawBytes[i];

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -430,9 +430,9 @@ const LoadingDataRows: React.FC<IDataPageProps> = props => (
 );
 
 const DataPageContents: React.FC<IDataPageProps> = props => {
+	const decorators = useRecoilValue(select.decoratorsPage(props.pageNo));
 	const dataPageSelector = select.editedDataPages(props.pageNo);
 	const [data] = useLastAsyncRecoilValue(dataPageSelector);
-	const decorators = useRecoilValue(select.decoratorsPage(props.pageNo));
 
 	return (
 		<>

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -446,11 +446,7 @@ const DataPageContents: React.FC<IDataPageProps> = props => {
 					width={props.columnWidth}
 					showDecodedText={props.showDecodedText}
 					isRowWithInsertDataCell={isRowWithInsertDataCell}
-					decorators={decorators.filter(decorator =>
-						decorator.range.overlaps(
-							new Range(offset - props.pageStart, offset - props.pageStart + props.columnWidth),
-						),
-					)}
+					decorators={decorators}
 				/>
 			))}
 		</>
@@ -715,7 +711,7 @@ const DataRowContents: React.FC<{
 			// Searches for the decorator, if any. Leverages the fact that
 			// the decorators are sorted by range.
 			while (j < decorators.length && decorators[j].range.start <= boffset) {
-				if (decorators[j].range.includes(boffset)) {
+				if (boffset >= decorators[j].range.start && boffset < decorators[j].range.end) {
 					decorator = decorators[j];
 					break;
 				}

--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -455,7 +455,7 @@ export const editedDataPages = selectorFamily({
 	},
 });
 
-/** Returns the starting decorator index for the given page number */
+/** Returns the decorators in a page */
 export const decoratorsPage = selectorFamily({
 	key: "decoratorsPage",
 	get:
@@ -466,9 +466,10 @@ export const decoratorsPage = selectorFamily({
 				return [];
 			}
 			const pageSize = get(dataPageSize);
-			const searcher = binarySearch<HexDecorator>(decorator => decorator.range.start);
-			const startIndex = searcher(pageSize * pageNumber, allDecorators);
-			const endIndex = searcher(pageSize * pageNumber + pageSize, allDecorators);
+			const searcherByEnd = binarySearch<HexDecorator>(decorator => decorator.range.end);
+			const startIndex = searcherByEnd(pageSize * pageNumber, allDecorators);
+			const searcherByStart = binarySearch<HexDecorator>(d => d.range.start);
+			const endIndex = searcherByStart(pageSize * pageNumber + pageSize+1, allDecorators);
 			return allDecorators.slice(startIndex, endIndex);
 		},
 });

--- a/media/editor/util.css
+++ b/media/editor/util.css
@@ -5,3 +5,5 @@
 	width: 100px;
 	height: 100px;
 }
+
+/* Decorators */

--- a/media/editor/util.css
+++ b/media/editor/util.css
@@ -7,3 +7,11 @@
 }
 
 /* Decorators */
+
+.diff-insert {
+	background-color: green;
+}
+
+.diff-delete {
+	background-color: red;
+}

--- a/media/editor/util.css
+++ b/media/editor/util.css
@@ -9,9 +9,25 @@
 /* Decorators */
 
 .diff-insert {
-	background-color: green;
+	background-color: rgba(156, 204, 44, 0.4);
+	filter: opacity(100%);
 }
 
 .diff-delete {
-	background-color: red;
+	background-color: rgba(255, 0, 0, 0.4);
+}
+
+.diff-empty {
+	background-image: linear-gradient(
+		-45deg,
+		var(--vscode-diffEditor-diagonalFill) 12.5%,
+		#0000 12.5%,
+		#0000 50%,
+		var(--vscode-diffEditor-diagonalFill) 50%,
+		var(--vscode-diffEditor-diagonalFill) 62.5%,
+		#0000 62.5%,
+		#0000 100%
+	);
+	background-size: 8px 8px;
+	color: transparent !important;
 }

--- a/media/editor/util.ts
+++ b/media/editor/util.ts
@@ -183,4 +183,6 @@ export const getScrollDimensions = (() => {
 })();
 
 export const HexDecoratorStyles: { [key in HexDecoratorType]: string } = {
+	[HexDecoratorType.Insert]: style.diffInsert,
+	[HexDecoratorType.Delete]: style.diffDelete,
 };

--- a/media/editor/util.ts
+++ b/media/editor/util.ts
@@ -185,4 +185,5 @@ export const getScrollDimensions = (() => {
 export const HexDecoratorStyles: { [key in HexDecoratorType]: string } = {
 	[HexDecoratorType.Insert]: style.diffInsert,
 	[HexDecoratorType.Delete]: style.diffDelete,
+	[HexDecoratorType.Empty]: style.diffEmpty,
 };

--- a/media/editor/util.ts
+++ b/media/editor/util.ts
@@ -3,6 +3,7 @@
 
 // Assorted helper functions
 
+import { HexDecoratorType } from "../../shared/decorators";
 import { Range } from "../../shared/util/range";
 import _style from "./util.css";
 
@@ -180,3 +181,6 @@ export const getScrollDimensions = (() => {
 		return value;
 	};
 })();
+
+export const HexDecoratorStyles: { [key in HexDecoratorType]: string } = {
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vscode/codicons": "0.0.27",
         "@vscode/extension-telemetry": "0.6.2",
         "cockatiel": "^3.1.2",
+        "diff": "^5.2.0",
         "js-base64": "^3.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.0",
+        "@types/diff": "^5.2.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^18.11.9",
         "@types/react": "^17.0.38",
@@ -1220,6 +1222,12 @@
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
     },
+    "node_modules/@types/diff": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.1.tgz",
+      "integrity": "sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2065,10 +2073,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3462,6 +3470,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -5112,6 +5130,12 @@
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
     },
+    "@types/diff": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.1.tgz",
+      "integrity": "sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5687,10 +5711,9 @@
       "dev": true
     },
     "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -6666,6 +6689,12 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
+    "@types/diff": "^5.2.1",
     "@types/mocha": "^9.0.0",
     "@types/node": "^18.11.9",
     "@types/react": "^17.0.38",
@@ -260,6 +261,7 @@
     "@vscode/codicons": "0.0.27",
     "@vscode/extension-telemetry": "0.6.2",
     "cockatiel": "^3.1.2",
+    "diff": "^5.2.0",
     "js-base64": "^3.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
         }
       }
     ],
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "{hexdiff}:/**/*.*": "hexEditor.hexedit"
+      }
+    },
     "customEditors": [
       {
         "viewType": "hexEditor.hexedit",
@@ -132,6 +137,11 @@
         "command": "hexEditor.copyOffsetAsDec",
         "category": "%name%",
         "title": "%hexEditor.copyOffsetAsDec%"
+      },
+      {
+        "command": "hexEditor.compareSelected",
+        "category": "%name%",
+        "title": "%hexEditor.compareSelected%"
       }
     ],
     "viewsContainers": {
@@ -163,6 +173,10 @@
         {
           "command": "hexEditor.switchEditMode",
           "when": "hexEditor:isActive"
+        },
+        {
+          "command": "hexEditor.compareSelected",
+          "when": "false"
         }
       ],
       "editor/title": [
@@ -187,6 +201,13 @@
           "when": "webviewId == 'hexEditor.hexedit'",
           "command": "hexEditor.copyAs",
           "group": "9_cutcopypaste"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "hexEditor.compareSelected",
+          "group": "3_compare",
+          "when": "listDoubleSelection"
         }
       ]
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,5 +16,6 @@
 	"hexEditor.switchEditMode": "Switch Edit Mode",
 	"hexEditor.copyOffsetAsDec": "Copy Offset as Decimal",
 	"hexEditor.copyOffsetAsHex": "Copy Offset as Hex",
+	"hexEditor.compareSelected": "Compare Selected in HexEditor (Experimental)",
 	"dataInspectorView": "Data Inspector"
 }

--- a/shared/decorators.ts
+++ b/shared/decorators.ts
@@ -3,6 +3,7 @@ import { Range } from "./util/range";
 export enum HexDecoratorType {
 	Insert,
 	Delete,
+	Empty,
 }
 
 export interface HexDecorator {

--- a/shared/decorators.ts
+++ b/shared/decorators.ts
@@ -1,5 +1,3 @@
-import { Range } from "./util/range";
-
 export enum HexDecoratorType {
 	Insert,
 	Delete,
@@ -8,5 +6,5 @@ export enum HexDecoratorType {
 
 export interface HexDecorator {
 	type: HexDecoratorType;
-	range: Range;
+	range: { start: number; end: number };
 }

--- a/shared/decorators.ts
+++ b/shared/decorators.ts
@@ -1,5 +1,8 @@
 import { Range } from "./util/range";
+
 export enum HexDecoratorType {
+	Insert,
+	Delete,
 }
 
 export interface HexDecorator {

--- a/shared/decorators.ts
+++ b/shared/decorators.ts
@@ -1,0 +1,8 @@
+import { Range } from "./util/range";
+export enum HexDecoratorType {
+}
+
+export interface HexDecorator {
+	type: HexDecoratorType;
+	range: Range;
+}

--- a/shared/diffWorker.ts
+++ b/shared/diffWorker.ts
@@ -1,0 +1,23 @@
+import { DiffMessageType, FromDiffWorkerMessage, ToDiffWorkerMessage } from "./diffWorkerProtocol";
+import { MessageHandler } from "./protocol";
+import { MyersDiff } from "./util/myers";
+
+function onMessage(message: ToDiffWorkerMessage): undefined | FromDiffWorkerMessage {
+	switch (message.type) {
+		case DiffMessageType.DiffDecoratorRequest:
+			const script = MyersDiff.lcs(message.original, message.modified);
+			const decorators = MyersDiff.toDecorator(script);
+			return {
+				type: DiffMessageType.DiffDecoratorResponse,
+				original: decorators.original,
+				modified: decorators.modified,
+			};
+	}
+}
+
+const messageHandler = new MessageHandler<FromDiffWorkerMessage, ToDiffWorkerMessage>(
+	async message => onMessage(message),
+	message => postMessage(message),
+);
+
+onmessage = e => messageHandler.handleMessage(e.data);

--- a/shared/diffWorkerProtocol.ts
+++ b/shared/diffWorkerProtocol.ts
@@ -1,0 +1,31 @@
+import { HexDecorator } from "./decorators";
+import { MessageHandler } from "./protocol";
+
+export type DiffExtensionHostMessageHandler = MessageHandler<
+	ToDiffWorkerMessage,
+	FromDiffWorkerMessage
+>;
+export type DiffWorkerMessageHandler = MessageHandler<FromDiffWorkerMessage, ToDiffWorkerMessage>;
+
+export type ToDiffWorkerMessage = DiffDecoratorsRequestMessage;
+export type FromDiffWorkerMessage = DiffDecoratorResponseMessage;
+export enum DiffMessageType {
+	// #region to diffworker
+	DiffDecoratorRequest,
+	// #endregion
+	// #region from diff worker
+	DiffDecoratorResponse,
+	// #endregion
+}
+
+export interface DiffDecoratorsRequestMessage {
+	type: DiffMessageType.DiffDecoratorRequest;
+	original: Uint8Array;
+	modified: Uint8Array;
+}
+
+export interface DiffDecoratorResponseMessage {
+	type: DiffMessageType.DiffDecoratorResponse;
+	original: HexDecorator[];
+	modified: HexDecorator[];
+}

--- a/shared/hexDiffModel.ts
+++ b/shared/hexDiffModel.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode";
+import { HexDocument } from "../src/hexDocument";
+import { HexDocumentModel } from "./hexDocumentModel";
+
+export class HexDiffModel {
+	constructor(
+		private readonly originalModel: HexDocumentModel,
+		private readonly modifiedModel: HexDocumentModel,
+	) {}
+
+	public async computeDecorators(doc: HexDocument) {}
+}

--- a/shared/hexDiffModel.ts
+++ b/shared/hexDiffModel.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import { HexDecorator } from "./decorators";
 import { HexDocumentModel } from "./hexDocumentModel";
 import { MyersDiff } from "./util/myers";
-
 export type HexDiffModelBuilder = typeof HexDiffModel.Builder.prototype;
 
 export class HexDiffModel {

--- a/shared/hexDiffModel.ts
+++ b/shared/hexDiffModel.ts
@@ -34,11 +34,14 @@ export class HexDiffModel {
 				const mArray = new Uint8Array(mSize);
 				await this.originalModel.readInto(0, oArray);
 				await this.modifiedModel.readInto(0, mArray);
-				const decorators = await this.messageHandler.sendRequest<DiffDecoratorResponseMessage>({
-					type: DiffMessageType.DiffDecoratorRequest,
-					original: oArray,
-					modified: mArray,
-				});
+				const decorators = await this.messageHandler.sendRequest<DiffDecoratorResponseMessage>(
+					{
+						type: DiffMessageType.DiffDecoratorRequest,
+						original: oArray,
+						modified: mArray,
+					},
+					[oArray.buffer, mArray.buffer],
+				);
 				this.decorators = decorators;
 			}
 			return uri.toString() === this.originalModel.uri.toString()

--- a/shared/hexDiffModel.ts
+++ b/shared/hexDiffModel.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
-import { HexDocument } from "../src/hexDocument";
+import { HexDecorator } from "./decorators";
 import { HexDocumentModel } from "./hexDocumentModel";
+
+export type HexDiffModelBuilder = typeof HexDiffModel.Builder.prototype;
 
 export class HexDiffModel {
 	constructor(
@@ -8,5 +10,61 @@ export class HexDiffModel {
 		private readonly modifiedModel: HexDocumentModel,
 	) {}
 
-	public async computeDecorators(doc: HexDocument) {}
+	public async computeDecorators(): Promise<HexDecorator[]> {
+		return [];
+	}
+
+	/**
+	 * Class to coordinate the creation of HexDiffModel
+	 * with both HexDocumentModels
+	 */
+	static Builder = class {
+		private originalModel: Promise<HexDocumentModel>;
+		private modifiedModel: Promise<HexDocumentModel>;
+		private resolveOriginalModel!: (
+			value: HexDocumentModel | PromiseLike<HexDocumentModel>,
+		) => void;
+		private resolveModifiedModel!: (
+			value: HexDocumentModel | PromiseLike<HexDocumentModel>,
+		) => void;
+		private builtModel?: HexDiffModel;
+		public onBuild?: () => void;
+
+		constructor(
+			public readonly originalUri: vscode.Uri,
+			public readonly modifiedUri: vscode.Uri,
+		) {
+			this.originalModel = new Promise<HexDocumentModel>(resolve => {
+				this.resolveOriginalModel = resolve;
+			});
+			this.modifiedModel = new Promise<HexDocumentModel>(resolve => {
+				this.resolveModifiedModel = resolve;
+			});
+		}
+
+		public setModel(model: HexDocumentModel) {
+			if (this.originalUri.toString() === model.uri.toString()) {
+				this.resolveOriginalModel(model);
+			} else if (this.modifiedUri.toString() === model.uri.toString()) {
+				this.resolveModifiedModel(model);
+			} else {
+				throw new Error("Provided doc does not match uris.");
+			}
+			return this;
+		}
+
+		public async build() {
+			const [originalModel, modifiedModel] = await Promise.all([
+				this.originalModel,
+				this.modifiedModel,
+			]);
+			if (this.builtModel === undefined) {
+				this.builtModel = new HexDiffModel(originalModel, modifiedModel);
+				if (this.onBuild) {
+					this.onBuild();
+				}
+			}
+			return this.builtModel;
+		}
+	};
 }

--- a/shared/hexDiffModel.ts
+++ b/shared/hexDiffModel.ts
@@ -17,7 +17,7 @@ export class HexDiffModel {
 	) {}
 
 	public async computeDecorators(uri: vscode.Uri): Promise<HexDecorator[]> {
-		return await this.saveGuard.execute(async () => {
+		return this.saveGuard.execute(async () => {
 			if (this.decorators === undefined) {
 				const editScript = await MyersDiff.lcs(this.originalModel, this.modifiedModel);
 				this.decorators = MyersDiff.toDecorator(editScript);

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -312,18 +312,21 @@ export class MessageHandler<TTo, TFrom> {
 
 	constructor(
 		public messageHandler: (msg: TFrom) => Promise<TTo | undefined>,
-		private readonly postMessage: (msg: WebviewMessage<TTo>) => void,
+		private readonly postMessage: (msg: WebviewMessage<TTo>, transfer?: Transferable[]) => void,
 	) {}
 
 	/** Sends a request without waiting for a response */
-	public sendEvent(body: TTo): void {
-		this.postMessage({ body, messageId: this.messageIdCounter++ });
+	public sendEvent(body: TTo, transfer?: Transferable[]): void {
+		this.postMessage({ body, messageId: this.messageIdCounter++ }, transfer);
 	}
 
 	/** Sends a request that expects a response */
-	public sendRequest<TResponse extends TFrom>(msg: TTo): Promise<TResponse> {
+	public sendRequest<TResponse extends TFrom>(
+		msg: TTo,
+		transfer?: Transferable[],
+	): Promise<TResponse> {
 		const id = this.messageIdCounter++;
-		this.postMessage({ body: msg, messageId: id });
+		this.postMessage({ body: msg, messageId: id }, transfer);
 		return new Promise<TResponse>((resolve, reject) => {
 			this.pendingMessages.set(id, { resolve: resolve as (msg: TFrom) => void, reject });
 		});

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -2,6 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import { HexDecorator } from "./decorators";
 import { HexDocumentEditOp } from "./hexDocumentModel";
 import { ISerializedEdits } from "./serialization";
 
@@ -80,6 +81,7 @@ export interface ReadyResponseMessage {
 	isReadonly: boolean;
 	isLargeFile: boolean;
 	editMode: HexDocumentEditOp.Insert | HexDocumentEditOp.Replace;
+	decorators: HexDecorator[];
 }
 
 export interface SetEditModeMessage {

--- a/shared/util/myers.ts
+++ b/shared/util/myers.ts
@@ -1,41 +1,17 @@
 import { ArrayChange, diffArrays } from "diff";
-import * as vscode from "vscode";
 import { HexDecorator, HexDecoratorType } from "../decorators";
-import { HexDocumentModel } from "../hexDocumentModel";
 import { Range } from "./range";
 
 /**
  * O(d^2) implementation
  */
 export class MyersDiff {
-	public static async lcs(original: HexDocumentModel, modified: HexDocumentModel) {
-		const oSize = await original.sizeWithEdits();
-		const mSize = await modified.sizeWithEdits();
-		if (oSize === undefined || mSize === undefined) {
-			throw new Error(vscode.l10n.t("HexEditor Diff: Failed to get file sizes."));
-		}
-
-		const oArray = new Uint8Array(oSize);
-		const mArray = new Uint8Array(mSize);
-		await original.readInto(0, oArray);
-		await modified.readInto(0, mArray);
+	public static lcs(original: Uint8Array, modified: Uint8Array) {
 		// the types in @types/diff are incomplete.
 		const changes: ArrayChange<any>[] | undefined = diffArrays(
-			oArray as any,
-			mArray as any,
-			{
-				timeout: 30000, // timeout in milliseconds
-			} as any,
+			original as any,
+			modified as any,
 		);
-
-		// Triggered timeout
-		if (changes === undefined) {
-			throw new Error(
-				vscode.l10n.t(
-					"HexEditor Diff: Reached maximum computation time to compute diff. This usually happens when comparing large files.",
-				),
-			);
-		}
 		return changes;
 	}
 

--- a/shared/util/myers.ts
+++ b/shared/util/myers.ts
@@ -134,10 +134,10 @@ export class MyersDiff {
 					range: new Range(diffType.atPositionOriginal, diffType.atPositionOriginal + 1),
 				});
 			} else {
-				//out.modified.push({
-				//	type: HexDecoratorType.Insert,
-				//	range: new Range(diffType.atPositionOriginal, diffType.atPositionOriginal + 1),
-				//});
+				out.original.push({
+					type: HexDecoratorType.Empty,
+					range: new Range(diffType.atPositionOriginal, diffType.atPositionOriginal + 1),
+				});
 				out.modified.push({
 					type: HexDecoratorType.Insert,
 					range: new Range(diffType.valuePositionModified, diffType.valuePositionModified + 1),

--- a/shared/util/myers.ts
+++ b/shared/util/myers.ts
@@ -1,0 +1,149 @@
+import { HexDecorator, HexDecoratorType } from "../decorators";
+import { HexDocumentModel } from "../hexDocumentModel";
+import { Range } from "./range";
+
+type ScriptType = InsertScript | DeleteScript;
+
+interface InsertScript {
+	type: "insert";
+	valuePositionModified: number;
+	atPositionOriginal: number;
+}
+
+interface DeleteScript {
+	type: "delete";
+	atPositionOriginal: number;
+}
+
+/**
+ * O(d^2) implementation
+ */
+export class MyersDiff {
+	public static async chunkified(model: HexDocumentModel) {
+		const size = await model.size();
+		if (size === undefined) {
+			throw new Error("undefined size");
+		}
+		let range = new Range(0, 1024);
+		const chunk = new Uint8Array(1024);
+		await model.readInto(0, chunk);
+
+		return {
+			get: async (offset: number) => {
+				if (!range.includes(offset)) {
+					range = new Range(
+						1024 * Math.floor(offset / 1024),
+						1024 * Math.floor(offset / 1024) + 1024,
+					);
+					await model.readInto(range.start, chunk);
+				}
+				return chunk[offset % 1024];
+			},
+		};
+	}
+
+	public static async lcs(
+		original: HexDocumentModel,
+		modified: HexDocumentModel,
+	): Promise<Array<ScriptType>> {
+		const originalChunk = await this.chunkified(original);
+		const modifiedChunk = await this.chunkified(modified);
+
+		const N = await original.size();
+		const M = await modified.size();
+		if (N === undefined || M === undefined) {
+			return [];
+		}
+		const max = N + M;
+		const V = new Array(2 * max + 2).fill(0);
+		V[1] = 0;
+		const trace: number[][] = [];
+
+		for (let d = 0; d <= max; d++) {
+			trace.push(V.slice());
+			for (let k = -d; k <= d; k += 2) {
+				let x: number;
+				if (k === -d || (k !== d && V.at(k - 1) < V.at(k + 1))) {
+					x = V.at(k + 1);
+				} else {
+					x = V.at(k - 1) + 1;
+				}
+
+				let y = x - k;
+				while (x < N && y < M && (await originalChunk.get(x)) === (await modifiedChunk.get(y))) {
+					x++;
+					y++;
+				}
+
+				V[k] = x;
+				if (x >= N && y >= M) {
+					return this.traceback(trace, N, M);
+				}
+			}
+		}
+		return [];
+	}
+
+	private static traceback(trace: number[][], n: number, m: number): Array<ScriptType> {
+		let d = trace.length - 1;
+		let x = n;
+		let y = m;
+		const script: Array<ScriptType> = [];
+
+		while (d >= 0) {
+			const v = trace[d];
+			const k = x - y;
+			let prevK: number;
+			if (k === -d || (k !== d && v.at(k - 1)! < v.at(k + 1)!)) {
+				prevK = k + 1;
+			} else {
+				prevK = k - 1;
+			}
+
+			const prevX = v.at(prevK)!;
+			const prevY = prevX - prevK;
+			while (x > prevX && y > prevY) {
+				x--;
+				y--;
+			}
+
+			if (d > 0) {
+				if (x == prevX) {
+					script.push({ type: "insert", valuePositionModified: y - 1, atPositionOriginal: x - 1 });
+				} else {
+					script.push({ type: "delete", atPositionOriginal: x - 1 });
+				}
+				x = prevX;
+				y = prevY;
+			}
+			d--;
+		}
+
+		return script.reverse();
+	}
+
+	public static toDecorator(script: ScriptType[]) {
+		const out: {
+			original: HexDecorator[];
+			modified: HexDecorator[];
+		} = { original: [], modified: [] };
+		for (const diffType of script) {
+			if (diffType.type === "delete") {
+				out.original.push({
+					type: HexDecoratorType.Delete,
+					range: new Range(diffType.atPositionOriginal, diffType.atPositionOriginal + 1),
+				});
+			} else {
+				//out.modified.push({
+				//	type: HexDecoratorType.Insert,
+				//	range: new Range(diffType.atPositionOriginal, diffType.atPositionOriginal + 1),
+				//});
+				out.modified.push({
+					type: HexDecoratorType.Insert,
+					range: new Range(diffType.valuePositionModified, diffType.valuePositionModified + 1),
+				});
+			}
+		}
+		return out;
+	}
+}

--- a/shared/util/uri.ts
+++ b/shared/util/uri.ts
@@ -1,0 +1,21 @@
+export interface HexEditorUriQuery {
+	baseAddress?: string;
+}
+
+/**
+ * Utility function to convert a Uri query string into a map
+ */
+export function parseQuery(queryString: string): HexEditorUriQuery {
+	const queries: HexEditorUriQuery = {};
+	if (queryString) {
+		const pairs = (queryString[0] === "?" ? queryString.substr(1) : queryString).split("&");
+		for (const q of pairs) {
+			const pair = q.split("=");
+			const name = pair.shift();
+			if (name) {
+				queries[name as keyof HexEditorUriQuery] = pair.join("=");
+			}
+		}
+	}
+	return queries;
+}

--- a/shared/util/uri.ts
+++ b/shared/util/uri.ts
@@ -1,5 +1,7 @@
 export interface HexEditorUriQuery {
 	baseAddress?: string;
+	token?: string;
+	side?: "modified" | "original";
 }
 
 /**
@@ -11,11 +13,32 @@ export function parseQuery(queryString: string): HexEditorUriQuery {
 		const pairs = (queryString[0] === "?" ? queryString.substr(1) : queryString).split("&");
 		for (const q of pairs) {
 			const pair = q.split("=");
-			const name = pair.shift();
+			const name = pair.shift() as keyof HexEditorUriQuery;
 			if (name) {
-				queries[name as keyof HexEditorUriQuery] = pair.join("=");
+				const value = pair.join("=");
+				if (name === "side") {
+					if (value === "modified" || value === "original" || value === undefined) {
+						queries.side = value;
+					}
+				} else {
+					queries[name] = value;
+				}
 			}
 		}
 	}
 	return queries;
+}
+
+/**
+ * Forms a valid HexEditor Query to be used in vscode.Uri
+ */
+export function formQuery(queries: HexEditorUriQuery): string {
+	const query: string[] = [];
+	for (const q in queries) {
+		const queryValue = queries[q as keyof HexEditorUriQuery];
+		if (queryValue !== undefined && queryValue !== "") {
+			query.push(`${q}=${queryValue}`);
+		}
+	}
+	return query.join("&");
 }

--- a/src/compareSelected.ts
+++ b/src/compareSelected.ts
@@ -1,9 +1,15 @@
 import * as vscode from "vscode";
+import { HexEditorRegistry } from "./hexEditorRegistry";
+import { HexDiffModel } from "../shared/hexDiffModel";
 
 // Initializes our custom editor with diff capabilities
 // @see https://github.com/microsoft/vscode/issues/97683
 // @see https://github.com/microsoft/vscode/issues/138525
-export const openCompareSelected = async (originalFile: vscode.Uri, modifiedFile: vscode.Uri) => {
+export const openCompareSelected = async (
+	originalFile: vscode.Uri,
+	modifiedFile: vscode.Uri,
+	registry: HexEditorRegistry,
+) => {
 	const diffOriginalUri = originalFile.with({
 		scheme: "hexdiff",
 	});
@@ -12,5 +18,7 @@ export const openCompareSelected = async (originalFile: vscode.Uri, modifiedFile
 		scheme: "hexdiff",
 	});
 
+	const diffModelBuilder = new HexDiffModel.Builder(diffOriginalUri, diffModifiedUri);
+	registry.addDiff(diffModelBuilder);
 	await vscode.commands.executeCommand("vscode.diff", diffOriginalUri, diffModifiedUri);
 };

--- a/src/compareSelected.ts
+++ b/src/compareSelected.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
-import { HexEditorRegistry } from "./hexEditorRegistry";
+import { DiffExtensionHostMessageHandler } from "../shared/diffWorkerProtocol";
 import { HexDiffModel } from "../shared/hexDiffModel";
+import { HexEditorRegistry } from "./hexEditorRegistry";
 
 // Initializes our custom editor with diff capabilities
 // @see https://github.com/microsoft/vscode/issues/97683
@@ -9,6 +10,7 @@ export const openCompareSelected = async (
 	originalFile: vscode.Uri,
 	modifiedFile: vscode.Uri,
 	registry: HexEditorRegistry,
+	diffExtensionHostMessageHandler: DiffExtensionHostMessageHandler,
 ) => {
 	const diffOriginalUri = originalFile.with({
 		scheme: "hexdiff",
@@ -18,7 +20,11 @@ export const openCompareSelected = async (
 		scheme: "hexdiff",
 	});
 
-	const diffModelBuilder = new HexDiffModel.Builder(diffOriginalUri, diffModifiedUri);
+	const diffModelBuilder = new HexDiffModel.Builder(
+		diffOriginalUri,
+		diffModifiedUri,
+		diffExtensionHostMessageHandler,
+	);
 	registry.addDiff(diffModelBuilder);
 	vscode.commands.executeCommand("vscode.diff", diffOriginalUri, diffModifiedUri);
 };

--- a/src/compareSelected.ts
+++ b/src/compareSelected.ts
@@ -20,5 +20,5 @@ export const openCompareSelected = async (
 
 	const diffModelBuilder = new HexDiffModel.Builder(diffOriginalUri, diffModifiedUri);
 	registry.addDiff(diffModelBuilder);
-	await vscode.commands.executeCommand("vscode.diff", diffOriginalUri, diffModifiedUri);
+	vscode.commands.executeCommand("vscode.diff", diffOriginalUri, diffModifiedUri);
 };

--- a/src/compareSelected.ts
+++ b/src/compareSelected.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+
+// Initializes our custom editor with diff capabilities
+// @see https://github.com/microsoft/vscode/issues/97683
+// @see https://github.com/microsoft/vscode/issues/138525
+export const openCompareSelected = async (originalFile: vscode.Uri, modifiedFile: vscode.Uri) => {
+	const diffOriginalUri = originalFile.with({
+		scheme: "hexdiff",
+	});
+
+	const diffModifiedUri = modifiedFile.with({
+		scheme: "hexdiff",
+	});
+
+	await vscode.commands.executeCommand("vscode.diff", diffOriginalUri, diffModifiedUri);
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,10 +157,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (!(leftFile instanceof vscode.Uri && rightFile instanceof vscode.Uri)) {
 				return;
 			}
-			//  Web-only
-			if (workerMessageHandler) {
-				openCompareSelected(leftFile, rightFile, registry, workerMessageHandler!);
-			}
+			openCompareSelected(leftFile, rightFile, registry, workerMessageHandler!);
 		},
 	);
 
@@ -177,7 +174,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(compareSelectedCommand);
 	context.subscriptions.push(
 		vscode.workspace.registerFileSystemProvider("hexdiff", new HexDiffFSProvider(), {
-			isCaseSensitive: true,
+			isCaseSensitive: typeof process !== 'undefined' && process.platform !== 'win32' && process.platform !== 'darwin',
 		}),
 	);
 	context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,7 @@
 
 import TelemetryReporter from "@vscode/extension-telemetry";
 import * as vscode from "vscode";
-import { FromDiffWorkerMessage, ToDiffWorkerMessage } from "../shared/diffWorkerProtocol";
 import { HexDocumentEditOp } from "../shared/hexDocumentModel";
-import { MessageHandler } from "../shared/protocol";
 import { openCompareSelected } from "./compareSelected";
 import { copyAs } from "./copyAs";
 import { DataInspectorView } from "./dataInspectorView";
@@ -13,6 +11,7 @@ import { showGoToOffset } from "./goToOffset";
 import { HexDiffFSProvider } from "./hexDiffFS";
 import { HexEditorProvider } from "./hexEditorProvider";
 import { HexEditorRegistry } from "./hexEditorRegistry";
+import { prepareLazyInitDiffWorker } from "./initWorker";
 import { showSelectBetweenOffsets } from "./selectBetweenOffsets";
 import StatusEditMode from "./statusEditMode";
 import StatusFocus from "./statusFocus";
@@ -42,7 +41,11 @@ function reopenWithHexEditor() {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-	const registry = new HexEditorRegistry();
+	// Prepares the worker to be lazily initialized
+	const initWorker = prepareLazyInitDiffWorker(context.extensionUri, workerDispose =>
+		context.subscriptions.push(workerDispose),
+	);
+	const registry = new HexEditorRegistry(initWorker);
 	// Register the data inspector as a separate view on the side
 	const dataInspectorProvider = new DataInspectorView(context.extensionUri, registry);
 	const configValues = readConfigFromPackageJson(context.extension);
@@ -112,41 +115,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	// Initializes worker for diffing
-	let worker: Worker;
-	const workerFilePath = vscode.Uri.joinPath(
-		context.extensionUri,
-		"dist",
-		"diffWorker.js",
-	).toString();
-
-	try {
-		worker = new Worker(workerFilePath);
-	} catch {
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const { Worker } = require("worker_threads") as typeof import("worker_threads");
-		const nodeWorker = new Worker(new URL(workerFilePath));
-		// Web and node js have different worker interfaces, so we share a function
-		// to initialize both workers the same way.
-		const ref = nodeWorker.addListener;
-		(nodeWorker as any).addEventListener = ref;
-		worker = nodeWorker as any;
-	}
-
-	const workerMessageHandler = new MessageHandler<ToDiffWorkerMessage, FromDiffWorkerMessage>(
-		// Always return undefined as the diff worker
-		// does not request anything from extension host
-		async () => undefined,
-		// worker.postMessage's transfer parameter type looks to be wrong because
-		// it should be set as optional.
-		(message, transfer) => worker.postMessage(message, transfer!),
-	);
-
-	worker.addEventListener("message", e =>
-		// e.data is used in web worker and e is used in node js worker
-		e.data ? workerMessageHandler.handleMessage(e.data) : workerMessageHandler.handleMessage(e as any),
-	);
-
 	const compareSelectedCommand = vscode.commands.registerCommand(
 		"hexEditor.compareSelected",
 		async (...args) => {
@@ -157,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (!(leftFile instanceof vscode.Uri && rightFile instanceof vscode.Uri)) {
 				return;
 			}
-			openCompareSelected(leftFile, rightFile, registry, workerMessageHandler!);
+			openCompareSelected(leftFile, rightFile);
 		},
 	);
 
@@ -180,9 +148,6 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		HexEditorProvider.register(context, telemetryReporter, dataInspectorProvider, registry),
 	);
-	context.subscriptions.push({
-		dispose: () => worker.terminate(),
-	});
 }
 
 export function deactivate(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		// Always return undefined as the diff worker
 		// does not request anything from extension host
 		async () => undefined,
-		message => worker.postMessage(message),
+		// worker.postMessage's transfer parameter type looks to be wrong because
+		// it should be set as optional.
+		(message, transfer) => worker.postMessage(message, transfer!),
 	);
 
 	worker.addEventListener("message", e =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			if (!(leftFile instanceof vscode.Uri && rightFile instanceof vscode.Uri)) {
 				return;
 			}
-			openCompareSelected(leftFile, rightFile);
+			openCompareSelected(leftFile, rightFile, registry);
 		},
 	);
 

--- a/src/fileSystemAdaptor.ts
+++ b/src/fileSystemAdaptor.ts
@@ -42,7 +42,8 @@ export const accessFile = async (
 						: !(fileStats.mode & 0o002); // other
 
 			if (fileStats.isFile()) {
-				return new NativeFileAccessor(uri, isReadonly, fs);
+				// Diff is readonly since the diff is only computed at the beginning once
+				return new NativeFileAccessor(uri, uri.scheme === "hexdiff" ? true : isReadonly, fs);
 			}
 		} catch {
 			// probably not node.js, or file does not exist

--- a/src/fileSystemAdaptor.ts
+++ b/src/fileSystemAdaptor.ts
@@ -24,7 +24,7 @@ export const accessFile = async (
 
 	// try to use native file access for local files to allow large files to be handled efficiently
 	// todo@connor4312/lramos: push forward extension host API for this.
-	if (uri.scheme === "file") {
+	if (uri.scheme === "file" || uri.scheme === "hexdiff") {
 		try {
 			// eslint-disable @typescript-eslint/no-var-requires
 			const fs = require("fs");

--- a/src/hexDiffFS.ts
+++ b/src/hexDiffFS.ts
@@ -2,27 +2,48 @@
 
 import * as vscode from "vscode";
 
-// Workaround to open our files in diff mode.
+/** changes our scheme to file so we can use workspace.fs */
+function toFileUri(uri: vscode.Uri) {
+	return uri.with({ scheme: "file" });
+}
+// Workaround to open our files in diff mode. Used by both web and node
+// to create a diff model, but the methods are only used in web whereas
+// in node we use node's fs.
 export class HexDiffFSProvider implements vscode.FileSystemProvider {
-	readDirectory(uri: vscode.Uri): [string, vscode.FileType][] | Thenable<[string, vscode.FileType][]> {
+	readDirectory(
+		uri: vscode.Uri,
+	): [string, vscode.FileType][] | Thenable<[string, vscode.FileType][]> {
 		throw new Error("Method not implemented.");
 	}
 	createDirectory(uri: vscode.Uri): void | Thenable<void> {
 		throw new Error("Method not implemented.");
 	}
 	readFile(uri: vscode.Uri): Uint8Array | Thenable<Uint8Array> {
-		throw new Error("Method not implemented.");
+		return vscode.workspace.fs.readFile(toFileUri(uri));
 	}
-	writeFile(uri: vscode.Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }): void | Thenable<void> {
-		throw new Error("Method not implemented.");
+	writeFile(
+		uri: vscode.Uri,
+		content: Uint8Array,
+		options: { readonly create: boolean; readonly overwrite: boolean },
+	): void | Thenable<void> {
+		return vscode.workspace.fs.writeFile(toFileUri(uri), content);
 	}
-	delete(uri: vscode.Uri, options: { readonly recursive: boolean; }): void | Thenable<void> {
-		throw new Error("Method not implemented.");
+
+	delete(uri: vscode.Uri, options: { readonly recursive: boolean }): void | Thenable<void> {
+		return vscode.workspace.fs.delete(toFileUri(uri), options);
 	}
-	rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
-		throw new Error("Method not implemented.");
+	rename(
+		oldUri: vscode.Uri,
+		newUri: vscode.Uri,
+		options: { readonly overwrite: boolean },
+	): void | Thenable<void> {
+		throw new Error("Method not implemented");
 	}
-	copy?(source: vscode.Uri, destination: vscode.Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
+	copy?(
+		source: vscode.Uri,
+		destination: vscode.Uri,
+		options: { readonly overwrite: boolean },
+	): void | Thenable<void> {
 		throw new Error("Method not implemented.");
 	}
 	private _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
@@ -34,6 +55,6 @@ export class HexDiffFSProvider implements vscode.FileSystemProvider {
 		return new vscode.Disposable(() => {});
 	}
 	stat(uri: vscode.Uri): vscode.FileStat | Thenable<vscode.FileStat> {
-		return vscode.workspace.fs.stat(uri);
+		return vscode.workspace.fs.stat(toFileUri(uri));
 	}
 }

--- a/src/hexDiffFS.ts
+++ b/src/hexDiffFS.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import * as vscode from "vscode";
+
+// Workaround to open our files in diff mode.
+export class HexDiffFSProvider implements vscode.FileSystemProvider {
+	readDirectory(uri: vscode.Uri): [string, vscode.FileType][] | Thenable<[string, vscode.FileType][]> {
+		throw new Error("Method not implemented.");
+	}
+	createDirectory(uri: vscode.Uri): void | Thenable<void> {
+		throw new Error("Method not implemented.");
+	}
+	readFile(uri: vscode.Uri): Uint8Array | Thenable<Uint8Array> {
+		throw new Error("Method not implemented.");
+	}
+	writeFile(uri: vscode.Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }): void | Thenable<void> {
+		throw new Error("Method not implemented.");
+	}
+	delete(uri: vscode.Uri, options: { readonly recursive: boolean; }): void | Thenable<void> {
+		throw new Error("Method not implemented.");
+	}
+	rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
+		throw new Error("Method not implemented.");
+	}
+	copy?(source: vscode.Uri, destination: vscode.Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
+		throw new Error("Method not implemented.");
+	}
+	private _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+	onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = this._emitter.event;
+	public watch(
+		uri: vscode.Uri,
+		options: { readonly recursive: boolean; readonly excludes: readonly string[] },
+	): vscode.Disposable {
+		return new vscode.Disposable(() => {});
+	}
+	stat(uri: vscode.Uri): vscode.FileStat | Thenable<vscode.FileStat> {
+		return vscode.workspace.fs.stat(uri);
+	}
+}

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -3,6 +3,7 @@
 
 import TelemetryReporter from "@vscode/extension-telemetry";
 import * as vscode from "vscode";
+import { HexDecorator } from "../shared/decorators";
 import { FileAccessor } from "../shared/fileAccessor";
 import {
 	HexDocumentEdit,
@@ -95,7 +96,15 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 	public get uri(): vscode.Uri {
 		return vscode.Uri.parse(this.model.uri);
 	}
-	
+
+	/**
+	 * Reads decorators from models, returning an array of all
+	 * decorators.
+	 */
+	public async readDecorators(): Promise<HexDecorator[]> {
+		return [];
+	}
+
 	/**
 	 * Reads data including unsaved edits from the model, returning an iterable
 	 * of Uint8Array chunks.

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -109,7 +109,7 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 	 */
 	public async readDecorators(): Promise<HexDecorator[]> {
 		if (this.diffModel) {
-			await this.diffModel.computeDecorators();
+			return await this.diffModel.computeDecorators(this.uri);
 		}
 		return [];
 	}

--- a/src/hexDocument.ts
+++ b/src/hexDocument.ts
@@ -109,7 +109,13 @@ export class HexDocument extends Disposable implements vscode.CustomDocument {
 	 */
 	public async readDecorators(): Promise<HexDecorator[]> {
 		if (this.diffModel) {
-			return await this.diffModel.computeDecorators(this.uri);
+			try {
+				return await this.diffModel.computeDecorators(this.uri);
+			} catch (e: unknown) {
+				vscode.window.showErrorMessage(
+					e instanceof Error ? e.message : vscode.l10n.t("Unknown Error in HexEditor Diff"),
+				);
+			}
 		}
 		return [];
 	}

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -334,6 +334,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 					isLargeFile: document.isLargeFile,
 					isReadonly: document.isReadonly,
 					editMode: document.editMode,
+					decorators: await document.readDecorators(),
 				};
 			case MessageType.SetSelectedCount:
 				document.selectionState = message;

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -69,14 +69,16 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 		openContext: vscode.CustomDocumentOpenContext,
 		_token: vscode.CancellationToken,
 	): Promise<HexDocument> {
+		const diff = this._registry.getDiff(uri);
+
 		const { document, accessor } = await HexDocument.create(
 			uri,
 			openContext,
 			this._telemetryReporter,
-			this._registry.getDiff(uri)
+			diff.builder,
 		);
 		const disposables: vscode.Disposable[] = [];
-
+		disposables.push(diff);
 		disposables.push(
 			document.onDidRevert(async () => {
 				const replaceFileSize = (await document.size()) ?? null;

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -73,6 +73,7 @@ export class HexEditorProvider implements vscode.CustomEditorProvider<HexDocumen
 			uri,
 			openContext,
 			this._telemetryReporter,
+			this._registry.getDiff(uri)
 		);
 		const disposables: vscode.Disposable[] = [];
 

--- a/src/hexEditorRegistry.ts
+++ b/src/hexEditorRegistry.ts
@@ -2,8 +2,10 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { HexDiffModelBuilder } from "../shared/hexDiffModel";
+import { DiffExtensionHostMessageHandler } from "../shared/diffWorkerProtocol";
+import { HexDiffModel, HexDiffModelBuilder } from "../shared/hexDiffModel";
 import { ExtensionHostMessageHandler } from "../shared/protocol";
+import { parseQuery } from "../shared/util/uri";
 import { Disposable } from "./dispose";
 import { HexDocument } from "./hexDocument";
 
@@ -11,7 +13,10 @@ const EMPTY: never[] = [];
 
 export class HexEditorRegistry extends Disposable {
 	private readonly docs = new Map<HexDocument, Set<ExtensionHostMessageHandler>>();
-	private readonly diffsBuilder = new Map<string, HexDiffModelBuilder>();
+	private readonly diffsBuilder = new Map<
+		string,
+		{ refCount: number; value: HexDiffModelBuilder }
+	>();
 	private onChangeEmitter = new vscode.EventEmitter<HexDocument | undefined>();
 	private _activeDocument?: HexDocument;
 
@@ -34,7 +39,7 @@ export class HexEditorRegistry extends Disposable {
 		return (this._activeDocument && this.docs.get(this._activeDocument)) || EMPTY;
 	}
 
-	constructor() {
+	constructor(private readonly initDiffWorker: () => DiffExtensionHostMessageHandler) {
 		super();
 		this._register(vscode.window.tabGroups.onDidChangeTabs(this.onChangedTabs, this));
 		this._register(vscode.window.tabGroups.onDidChangeTabGroups(this.onChangedTabs, this));
@@ -70,18 +75,38 @@ export class HexEditorRegistry extends Disposable {
 		};
 	}
 
-	/** adds a diff model */
-	public addDiff(diffModelBuilder: HexDiffModelBuilder) {
-		this.diffsBuilder.set(diffModelBuilder.modifiedUri.toString(), diffModelBuilder);
-		this.diffsBuilder.set(diffModelBuilder.originalUri.toString(), diffModelBuilder);
-		diffModelBuilder.onBuild = () => {
-			this.diffsBuilder.delete(diffModelBuilder.modifiedUri.toString());
-			this.diffsBuilder.delete(diffModelBuilder.originalUri.toString());
-		};
-	}
 	/** returns a diff model using the file uri */
-	public getDiff(uri: vscode.Uri): HexDiffModelBuilder | undefined {
-		return this.diffsBuilder.get(uri.toString());
+	public getDiff(uri: vscode.Uri): {
+		builder: HexDiffModelBuilder | undefined;
+		dispose: () => void;
+	} {
+		const { token } = parseQuery(uri.query);
+		if (token === undefined) {
+			return { builder: undefined, dispose: () => {} };
+		}
+		// Lazily initializes the diff worker, if it isn't
+		// iniitalized already
+		const messageHandler = this.initDiffWorker();
+
+		// Creates a new diff model
+		if (!this.diffsBuilder.has(token)) {
+			this.diffsBuilder.set(token, {
+				refCount: 0,
+				value: new HexDiffModel.Builder(messageHandler),
+			});
+		}
+		const builder = this.diffsBuilder.get(token)!;
+		builder.refCount++;
+
+		return {
+			builder: builder.value,
+			dispose: () => {
+				builder.refCount--;
+				if (builder.refCount === 0) {
+					this.diffsBuilder.delete(token);
+				}
+			},
+		};
 	}
 
 	private onChangedTabs() {

--- a/src/initWorker.ts
+++ b/src/initWorker.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+import {
+	DiffExtensionHostMessageHandler,
+	FromDiffWorkerMessage,
+	ToDiffWorkerMessage,
+} from "../shared/diffWorkerProtocol";
+import { MessageHandler } from "../shared/protocol";
+
+/** Prepares diff worker to be lazily initialized and instantiated once*/
+export function prepareLazyInitDiffWorker(
+	extensionUri: vscode.Uri,
+	addDispose: (dispose: vscode.Disposable) => void,
+) {
+	let messageHandler: DiffExtensionHostMessageHandler;
+	return () => {
+		if (!messageHandler) {
+			const { msgHandler, dispose } = initDiffWorker(extensionUri);
+			messageHandler = msgHandler;
+			addDispose({ dispose: dispose });
+		}
+		return messageHandler;
+	};
+}
+
+/**	Initializes the diff worker */
+function initDiffWorker(extensionUri: vscode.Uri): {
+	msgHandler: DiffExtensionHostMessageHandler;
+	dispose: () => void;
+} {
+	let worker: Worker;
+	const workerFilePath = vscode.Uri.joinPath(extensionUri, "dist", "diffWorker.js").toString();
+
+	try {
+		worker = new Worker(workerFilePath);
+	} catch {
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const { Worker } = require("worker_threads") as typeof import("worker_threads");
+		const nodeWorker = new Worker(new URL(workerFilePath));
+		// Web and node js have different worker interfaces, so we share a function
+		// to initialize both workers the same way.
+		const ref = nodeWorker.addListener;
+		(nodeWorker as any).addEventListener = ref;
+		worker = nodeWorker as any;
+	}
+
+	const workerMessageHandler = new MessageHandler<ToDiffWorkerMessage, FromDiffWorkerMessage>(
+		// Always return undefined as the diff worker
+		// does not request anything from extension host
+		async () => undefined,
+		// worker.postMessage's transfer parameter type looks to be wrong because
+		// it should be set as optional.
+		(message, transfer) => worker.postMessage(message, transfer!),
+	);
+
+	worker.addEventListener("message", e =>
+		// e.data is used in web worker and e is used in node js worker
+		e.data
+			? workerMessageHandler.handleMessage(e.data)
+			: workerMessageHandler.handleMessage(e as any),
+	);
+	return { msgHandler: workerMessageHandler, dispose: () => worker.terminate() };
+}


### PR DESCRIPTION
MVP to receive some early feedback on the diff process. (Closes #47 )

As I was unsure if it was possible to do this since there isn't any explicit API to create custom diff, I rushed most components to figure out the diff process. There is still plenty of work to do, but hopefully this shows how the diff can look. 
### Simple Diff Algorithm
![diffv1](https://github.com/microsoft/vscode-hexeditor/assets/136352470/76519e24-03a6-4ac8-82d7-cd05b31609c1)

### Improved Diff Alg
![image](https://github.com/microsoft/vscode-hexeditor/assets/136352470/ffa90a10-1952-46b7-ab5e-58274b6d6281)


There are some issues due to VSCode not supporting custom diff editors (I think), below is a list. 
### (Unfixable?) Issues
- [ ] Switching Tabs - `vscode.window.TabGroup` does not have a class type for custom editor's diff, so `.input` is undefined. 
- [ ] No Status Bar Item display
- [ ] Keybinds do not work  - `Insert` does not work
