### PR TITLE
fix: ctrl+g scroll state being lost when restoring editor

### DIFF
--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -264,6 +264,7 @@ export const offset = atom({
 
 			registerHandler(MessageType.GoToOffset, msg => {
 				const s = fx.getLoadable(columnWidth).getValue();
+				vscode.setState({ ...vscode.getState(), offset: msg.offset });
 				fx.setSelf(startOfRowContainingByte(msg.offset, s));
 			});
 		},


### PR DESCRIPTION
Fixes #458