### PR TITLE
feat: dim zero bytes

### DIFF
--- a/media/editor/dataDisplay.css
+++ b/media/editor/dataDisplay.css
@@ -129,3 +129,7 @@
 .data-cell-char {
 	width: calc(var(--cell-size) * 0.7) !important;
 }
+
+.dim-zero-bytes {
+	color: var(--vscode-tab-unfocusedInactiveForeground);
+}

--- a/media/editor/dataDisplay.tsx
+++ b/media/editor/dataDisplay.tsx
@@ -661,6 +661,8 @@ const DataCell: React.FC<{
 			: firstOctetOfEdit === undefined // Assumes HexDocumentEditOp.Insert
 				? style.dataCellInsertBefore
 				: style.dataCellInsertMiddle;
+
+	const dimZeroBytes = useRecoilValue(select.dimZeroBytes);
 	return (
 		<span
 			ref={elRef}
@@ -677,6 +679,7 @@ const DataCell: React.FC<{
 				isSelected && style.dataCellSelected,
 				isHovered && isSelected && style.dataCellSelectedHovered,
 				useIsUnsaved(offset) && style.dataCellUnsaved,
+				dimZeroBytes && value === 0 && style.dimZeroBytes,
 			)}
 			onMouseEnter={onMouseEnter}
 			onMouseDown={onMouseDown}

--- a/media/editor/state.ts
+++ b/media/editor/state.ts
@@ -200,6 +200,11 @@ export const showDecodedText = selector({
 	get: ({ get }) => get(editorSettings).showDecodedText,
 });
 
+export const dimZeroBytes = selector({
+	key: "dimZeroBytes",
+	get: ({ get }) => get(editorSettings).dimZeroBytes,
+});
+
 // Atom used to invalidate data when a reload is requested.
 const reloadGeneration = atom({
 	key: "reloadGeneration",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
             "type": "boolean",
             "default": false,
             "description": "%hexeditor.showOpenFileButton%"
+          },
+          "hexeditor.dimZeroBytes": {
+            "type": "boolean",
+            "default": false,
+            "description": "%hexeditor.dimZeroBytes%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,6 +9,7 @@
 	"hexeditor.columnWidth": "The number of bytes per row to show in the editor.",
 	"hexeditor.showDecodedText": "Whether decoded text should be shown in the editor.",
 	"hexeditor.showOpenFileButton": "Show Hex Editor button in editor menu.",
+	"hexeditor.dimZeroBytes": "Whether to dim all zero bytes to help non-zero data stand out",
 	"hexEditor.openFile": "Open Active File in Hex Editor",
 	"hexEditor.goToOffset": "Go To Offset",
 	"hexEditor.selectBetweenOffsets": "Select Between Offsets",

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -64,6 +64,7 @@ export interface IEditorSettings {
 	columnWidth: number;
 	inspectorType: InspectorLocation;
 	defaultEndianness: Endianness;
+	dimZeroBytes: boolean;
 }
 
 export interface ICodeSettings {

--- a/src/hexEditorProvider.ts
+++ b/src/hexEditorProvider.ts
@@ -37,6 +37,7 @@ const defaultEditorSettings: Readonly<IEditorSettings> = {
 	showDecodedText: true,
 	defaultEndianness: Endianness.Little,
 	inspectorType: InspectorLocation.Aside,
+	dimZeroBytes: false,
 };
 
 const editorSettingsKeys = Object.keys(defaultEditorSettings) as readonly (keyof IEditorSettings)[];


### PR DESCRIPTION
Greys out zero bytes to make non-zero data stand out. Credits to @armandas for the CSS. Closes #419 

![Recording 2024-11-18 at 18 29 03](https://github.com/user-attachments/assets/b882d89d-858b-415f-822d-e90e5876af87)
